### PR TITLE
feat: allow custom name for style created for imported tileset

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -107,7 +107,10 @@ export interface IdResource {
   id: string
 }
 export interface Api {
-  importMBTiles(filePath: string): Promise<TileJSON & IdResource>
+  importMBTiles(params: {
+    filePath: string
+    styleName?: string
+  }): Promise<TileJSON & IdResource>
   // getImportProgress(tilesetId: string): Promise<ImportProgressEmitter>
   createTileset(tileset: TileJSON): Promise<TileJSON & IdResource>
   putTileset(id: string, tileset: TileJSON): Promise<TileJSON & IdResource>
@@ -347,7 +350,7 @@ function createApi({
   }
 
   const api: Api = {
-    async importMBTiles(filePath: string) {
+    async importMBTiles({ filePath, styleName }) {
       const filePathWithExtension =
         path.extname(filePath) === '.mbtiles' ? filePath : filePath + '.mbtiles'
 
@@ -382,7 +385,7 @@ function createApi({
 
       const { id: styleId } = await api.createStyleForTileset(
         tileset.id,
-        tileset.name
+        styleName || tileset.name
       )
 
       // TODO: `style` is not guaranteed to exist since the tileset could be a vector tileset

--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -328,10 +328,12 @@ test('POST /tilesets/import creates tileset', async (t) => {
 test('POST /tilesets/import creates style for created tileset', async (t) => {
   const { sampleMbTilesPath, server } = t.context as TestContext
 
+  const customStyleName = 'Test Style Name'
+
   const importResponse = await server.inject({
     method: 'POST',
     url: '/tilesets/import',
-    payload: { filePath: sampleMbTilesPath },
+    payload: { filePath: sampleMbTilesPath, styleName: customStyleName },
   })
 
   const { id: createdTilesetId } = importResponse.json<
@@ -368,6 +370,12 @@ test('POST /tilesets/import creates style for created tileset', async (t) => {
   )
 
   t.ok(matchingStyle)
+
+  t.equal(
+    matchingStyle?.name,
+    customStyleName,
+    'style uses provided name for name field'
+  )
 })
 
 /**

--- a/src/routes/tilesets.ts
+++ b/src/routes/tilesets.ts
@@ -19,6 +19,7 @@ const PutTilesetParamsSchema = T.Object({
 
 const ImportMBTilesBodySchema = T.Object({
   filePath: T.String(),
+  styleName: T.Optional(T.String()),
 })
 
 // const GetImportProgressParamsSchema = T.Object({
@@ -128,7 +129,7 @@ const tilesets: FastifyPluginAsync = async function (fastify) {
       },
     },
     async function (request, reply) {
-      const tilejson = await request.api.importMBTiles(request.body.filePath)
+      const tilejson = await request.api.importMBTiles(request.body)
       reply.header('Location', `${fastify.prefix}/${tilejson.id}`)
       return tilejson
     }


### PR DESCRIPTION
More of a RFC PR but from #9 :

> Need to read mbtiles, and a space for the user to name it if there is no name

This detail was omitted in the initial implementation. This PR surfaces a field that the client can provide for the import endpoint (`styleName`) to name the style that's created. From a UI perspective, this would support a flow where the user may provide a custom name for the created style for the tileset they wish to import (as opposed to a multistep flow). 

Based on the [mbtiles spec](https://github.com/mapbox/mbtiles-spec/blob/master/1.3/spec.md#content), the tileset must have a `name` defined for it, so not entirely sure if this kind of feature is highly necessary if we already use the name of the tileset for the style name