### PR TITLE
fix: fix race condition with piscina and worker

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -411,6 +411,7 @@ function createApi({
       activeImports.set(importId, port2)
 
       return new Promise((res, rej) => {
+        let workerDone = false
         // Initially use a longer duration to account for worker startup
         let timeoutId = createTimeout(10000)
 
@@ -437,7 +438,10 @@ function createApi({
           .catch((err) => {
             rej(err)
           })
-          .finally(cleanup)
+          .finally(() => {
+            cleanup()
+            workerDone = true
+          })
 
         function handleFirstProgressMessage(message: PortMessage) {
           if (message.type === 'progress') {
@@ -454,9 +458,11 @@ function createApi({
         }
 
         function onMessageTimeout() {
-          abortSignaler.emit('abort')
+          if (workerDone) return
 
           cleanup()
+
+          abortSignaler.emit('abort')
 
           try {
             db.prepare(

--- a/src/lib/mbtiles_import_worker.js
+++ b/src/lib/mbtiles_import_worker.js
@@ -156,9 +156,6 @@ function importMbTiles({
     }
   }
 
-  db.close()
-  mbTilesDb.close()
-
   const baseFinalMessage = {
     importId,
     soFar: bytesSoFar,
@@ -175,4 +172,7 @@ function importMbTiles({
     ...baseFinalMessage,
     type: 'complete',
   })
+
+  db.close()
+  mbTilesDb.close()
 }


### PR DESCRIPTION
noticed an issue where the `finally` call on the piscina instance would execute before the final two messages from the worker (final progress and complete) would be received by the port. for some reason, moving the post message calls in the worker to before we close the db instances solved the problem, although I'm a little puzzled as to why (does one of those calls send some kind of signal that piscina listens for?)