### PR TITLE
WIP: fix fastify error in import progress endpoint

### DIFF
--- a/src/routes/imports.ts
+++ b/src/routes/imports.ts
@@ -47,7 +47,7 @@ const imports: FastifyPluginAsync = async function (fastify) {
           })
         }
 
-        return
+        return reply
       }
 
       port.on('message', onMessage)
@@ -59,6 +59,8 @@ const imports: FastifyPluginAsync = async function (fastify) {
       function onMessage(message: PortMessage) {
         reply.sse({ data: JSON.stringify(message) })
       }
+
+      return reply
     }
   )
 }


### PR DESCRIPTION
When enabling the fastify logger, the following error message shows up when a request to `GET /imports/progress/:importId` is made:

```json
{
  "type": "FastifyError",
  "message": "Promise may not be fulfilled with 'undefined' when statusCode is not 204",
  "stack": "FastifyError: Promise may not be fulfilled with 'undefined' when statusCode is not 204\n    at /Users/andrewchou/GitHub/digidem/mapeo-map-server/node_modules/fastify/lib/wrapThenable.js:30:30",
  "name": "FastifyError",
  "code": "FST_ERR_PROMISE_NOT_FULFILLED",
  "statusCode": 500
}
```

According to some online searching, the solution is supposedly to [return the reply in the handler](https://github.com/fastify/fastify/discussions/3549#discussioncomment-1848650). This PR currently has this change, but it doesn't seem to fix the issue. wondering if it's related to `fastify-sse-v2` 🤔 