### PR TITLE
use teardown hook for tests

### DIFF
--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -1,4 +1,4 @@
-import test from 'tape'
+import test, { Test } from 'tape'
 import tmp from 'tmp'
 import path from 'path'
 import fs from 'fs'
@@ -65,7 +65,7 @@ test.onFinish(() => {
   mockTileServer.close()
 })
 
-function createContext() {
+function createContext(t: Test) {
   const { name: dataDir } = tmp.dirSync({ unsafeCleanup: true })
 
   const dbPath = path.resolve(dataDir, 'test.db')
@@ -80,6 +80,8 @@ function createContext() {
   ) => createMapServer(fastifyOpts, { dbPath })
 
   const server = createServer()
+
+  t.teardown(() => server.close())
 
   const context = {
     createServer,
@@ -117,9 +119,7 @@ async function waitForImportCompletion(endpoint: string) {
  */
 
 test('GET /tilesets when no tilesets exist returns an empty array', async (t) => {
-  const { server } = createContext()
-
-  t.teardown(() => server.close())
+  const { server } = createContext(t)
 
   const response = await server.inject({ method: 'GET', url: '/tilesets' })
 
@@ -135,9 +135,7 @@ test('GET /tilesets when no tilesets exist returns an empty array', async (t) =>
 })
 
 test('GET /tilesets when tilesets exist returns an array of the tilesets', async (t) => {
-  const { sampleTileJSON, server } = createContext()
-
-  t.teardown(() => server.close())
+  const { sampleTileJSON, server } = createContext(t)
 
   await server.inject({
     method: 'POST',
@@ -161,9 +159,7 @@ test('GET /tilesets when tilesets exist returns an array of the tilesets', async
 })
 
 test('POST /tilesets when tileset does not exist creates a tileset and returns it', async (t) => {
-  const { sampleTileJSON, server } = createContext()
-
-  t.teardown(() => server.close())
+  const { sampleTileJSON, server } = createContext(t)
 
   const expectedId = '23z3tmtw49abd8b4ycah9x94ykjhedam'
   const expectedTileUrl = `http://localhost:80/tilesets/${expectedId}/{z}/{x}/{y}`
@@ -191,9 +187,7 @@ test('POST /tilesets when tileset does not exist creates a tileset and returns i
 })
 
 test('POST /tilesets creates a style for the raster tileset', async (t) => {
-  const { sampleTileJSON, server } = createContext()
-
-  t.teardown(() => server.close())
+  const { sampleTileJSON, server } = createContext(t)
 
   const responseTilesetsPost = await server.inject({
     method: 'POST',
@@ -244,9 +238,7 @@ test('POST /tilesets creates a style for the raster tileset', async (t) => {
 })
 
 test('PUT /tilesets when tileset exists returns the updated tileset', async (t) => {
-  const { sampleTileJSON, server } = createContext()
-
-  t.teardown(() => server.close())
+  const { sampleTileJSON, server } = createContext(t)
 
   const initialResponse = await server.inject({
     method: 'POST',
@@ -272,9 +264,7 @@ test('PUT /tilesets when tileset exists returns the updated tileset', async (t) 
 })
 
 test('PUT /tilesets when providing an incorrect id returns 400 status code', async (t) => {
-  const { sampleTileJSON, server } = createContext()
-
-  t.teardown(() => server.close())
+  const { sampleTileJSON, server } = createContext(t)
 
   const response = await server.inject({
     method: 'PUT',
@@ -286,9 +276,7 @@ test('PUT /tilesets when providing an incorrect id returns 400 status code', asy
 })
 
 test('PUT /tilesets when tileset does not exist returns 404 status code', async (t) => {
-  const { sampleTileJSON, server } = createContext()
-
-  t.teardown(() => server.close())
+  const { sampleTileJSON, server } = createContext(t)
 
   const response = await server.inject({
     method: 'PUT',
@@ -304,9 +292,7 @@ test('PUT /tilesets when tileset does not exist returns 404 status code', async 
  */
 
 test('GET /tile before tileset is created returns 404 status code', async (t) => {
-  const { server } = createContext()
-
-  t.teardown(() => server.close())
+  const { server } = createContext(t)
 
   const response = await server.inject({
     method: 'GET',
@@ -317,9 +303,7 @@ test('GET /tile before tileset is created returns 404 status code', async (t) =>
 })
 
 test('GET /tile of png format returns a tile image', async (t) => {
-  const { sampleTileJSON, server } = createContext()
-
-  t.teardown(() => server.close())
+  const { sampleTileJSON, server } = createContext(t)
 
   // Create initial tileset
   const initialResponse = await server.inject({
@@ -347,9 +331,7 @@ test('GET /tile of png format returns a tile image', async (t) => {
 })
 
 test('POST /tilesets/import fails when providing path for non-existent file', async (t) => {
-  const { server } = createContext()
-
-  t.teardown(() => server.close())
+  const { server } = createContext(t)
 
   const importResponse = await server.inject({
     method: 'POST',
@@ -362,9 +344,7 @@ test('POST /tilesets/import fails when providing path for non-existent file', as
 })
 
 test('POST /tilesets/import fails when provided vector tiles format', async (t) => {
-  const { server } = createContext()
-
-  t.teardown(() => server.close())
+  const { server } = createContext(t)
 
   const unsupportedFixturePath = path.resolve(
     __dirname,
@@ -385,9 +365,7 @@ test('POST /tilesets/import fails when provided vector tiles format', async (t) 
 })
 
 test('POST /tilesets/import creates tileset', async (t) => {
-  const { sampleMbTilesPath, server } = createContext()
-
-  t.teardown(() => server.close())
+  const { sampleMbTilesPath, server } = createContext(t)
 
   const importResponse = await server.inject({
     method: 'POST',
@@ -410,9 +388,7 @@ test('POST /tilesets/import creates tileset', async (t) => {
 })
 
 test('POST /tilesets/import creates style for created tileset', async (t) => {
-  const { sampleMbTilesPath, server } = createContext()
-
-  t.teardown(() => server.close())
+  const { sampleMbTilesPath, server } = createContext(t)
 
   const importResponse = await server.inject({
     method: 'POST',
@@ -463,9 +439,7 @@ test('POST /tilesets/import creates style for created tileset', async (t) => {
 test('POST /tilesets/import multiple times using same source file works', async (t) => {
   t.plan(5)
 
-  const { sampleMbTilesPath, server } = createContext()
-
-  t.teardown(() => server.close())
+  const { sampleMbTilesPath, server } = createContext(t)
 
   async function requestImport() {
     return await server.inject({
@@ -513,9 +487,7 @@ test('POST /tilesets/import multiple times using same source file works', async 
 })
 
 test('POST /tilesets/import storage used by tiles is roughly equivalent to that of source', async (t) => {
-  const { sampleMbTilesPath, server } = createContext()
-
-  t.teardown(() => server.close())
+  const { sampleMbTilesPath, server } = createContext(t)
 
   function getMbTilesByteCount() {
     const mbTilesDb = new Database(sampleMbTilesPath, { readonly: true })
@@ -565,9 +537,7 @@ test('POST /tilesets/import storage used by tiles is roughly equivalent to that 
 
 // TODO: This may eventually become a failing test if styles that share tiles reuse new ones that are stored
 test('POST /tilesets/import subsequent imports do not affect storage calculation for existing styles', async (t) => {
-  const { sampleMbTilesPath, server } = createContext()
-
-  t.teardown(() => server.close())
+  const { sampleMbTilesPath, server } = createContext(t)
 
   const address = await server.listen(0)
 
@@ -617,9 +587,7 @@ test('POST /tilesets/import subsequent imports do not affect storage calculation
  */
 
 test('GET /imports/:importId returns 404 error when import does not exist', async (t) => {
-  const { server } = createContext()
-
-  t.teardown(() => server.close())
+  const { server } = createContext(t)
 
   const getImportInfoResponse = await server.inject({
     method: 'GET',
@@ -630,9 +598,7 @@ test('GET /imports/:importId returns 404 error when import does not exist', asyn
 })
 
 test('GET /imports/progress/:importId returns 404 error when import does not exist', async (t) => {
-  const { server } = createContext()
-
-  t.teardown(() => server.close())
+  const { server } = createContext(t)
 
   const address = await server.listen(0)
 
@@ -650,9 +616,7 @@ test('GET /imports/progress/:importId returns 404 error when import does not exi
 })
 
 test('GET /imports/:importId returns import information', async (t) => {
-  const { sampleMbTilesPath, server } = createContext()
-
-  t.teardown(() => server.close())
+  const { sampleMbTilesPath, server } = createContext(t)
 
   const createImportResponse = await server.inject({
     method: 'POST',
@@ -677,9 +641,7 @@ test('GET /imports/:importId returns import information', async (t) => {
 test('GET /imports/progress/:importId returns import progress info (SSE)', async (t) => {
   t.plan(5)
 
-  const { sampleMbTilesPath, server } = createContext()
-
-  t.teardown(() => server.close())
+  const { sampleMbTilesPath, server } = createContext(t)
 
   const createImportResponse = await server.inject({
     method: 'POST',
@@ -765,9 +727,7 @@ test('GET /imports/progress/:importId returns import progress info (SSE)', async
 test('GET /imports/progress/:importId when import is already completed returns single complete event (SSE)', async (t) => {
   t.plan(1)
 
-  const { sampleMbTilesPath, server } = createContext()
-
-  t.teardown(() => server.close())
+  const { sampleMbTilesPath, server } = createContext(t)
 
   const createImportResponse = await server.inject({
     method: 'POST',
@@ -805,9 +765,7 @@ test('GET /imports/progress/:importId when import is already completed returns s
 })
 
 test('GET /imports/:importId on failed import returns import with error state', async (t) => {
-  const { createServer, sampleMbTilesPath, server: server1 } = createContext()
-
-  t.teardown(() => server1.close())
+  const { createServer, sampleMbTilesPath, server: server1 } = createContext(t)
 
   const createImportResponse = await server1.inject({
     method: 'POST',
@@ -846,9 +804,7 @@ test('GET /imports/:importId on failed import returns import with error state', 
 // - POST /styles (style via url)
 
 test('POST /styles with invalid style returns 400 status code', async (t) => {
-  const { server, sampleStyleJSON } = createContext()
-
-  t.teardown(() => server.close())
+  const { server, sampleStyleJSON } = createContext(t)
 
   const responsePost = await server.inject({
     method: 'POST',
@@ -862,9 +818,7 @@ test('POST /styles with invalid style returns 400 status code', async (t) => {
 // Reflects the case where a user is providing the style directly
 // We'd enforce at the application level that they provide an `id` field in their body
 test('POST /styles when providing an id returns resource with the same id', async (t) => {
-  const { server, sampleStyleJSON } = createContext()
-
-  t.teardown(() => server.close())
+  const { server, sampleStyleJSON } = createContext(t)
 
   const expectedId = 'example-style-id'
 
@@ -884,9 +838,7 @@ test('POST /styles when providing an id returns resource with the same id', asyn
 })
 
 test('POST /styles when style exists returns 409', async (t) => {
-  const { server, sampleStyleJSON } = createContext()
-
-  t.teardown(() => server.close())
+  const { server, sampleStyleJSON } = createContext(t)
 
   const payload = {
     style: sampleStyleJSON,
@@ -912,9 +864,7 @@ test('POST /styles when style exists returns 409', async (t) => {
 })
 
 test('POST /styles when providing valid style returns resource with id and altered style', async (t) => {
-  const { server, sampleStyleJSON } = createContext()
-
-  t.teardown(() => server.close())
+  const { server, sampleStyleJSON } = createContext(t)
 
   const responsePost = await server.inject({
     method: 'POST',
@@ -974,9 +924,7 @@ test('POST /styles when providing valid style returns resource with id and alter
 })
 
 test('POST /styles when required Mapbox access token is missing returns 400 status code', async (t) => {
-  const { server, sampleStyleJSON } = createContext()
-
-  t.teardown(() => server.close())
+  const { server, sampleStyleJSON } = createContext(t)
 
   const responsePost = await server.inject({
     method: 'POST',
@@ -989,9 +937,7 @@ test('POST /styles when required Mapbox access token is missing returns 400 stat
 })
 
 test('GET /styles/:styleId when style does not exist return 404 status code', async (t) => {
-  const { server } = createContext()
-
-  t.teardown(() => server.close())
+  const { server } = createContext(t)
 
   const id = 'nonexistent-id'
 
@@ -1004,9 +950,7 @@ test('GET /styles/:styleId when style does not exist return 404 status code', as
 })
 
 test('GET /styles/:styleId when style exists returns style with sources pointing to offline tilesets', async (t) => {
-  const { server, sampleStyleJSON } = createContext()
-
-  t.teardown(() => server.close())
+  const { server, sampleStyleJSON } = createContext(t)
 
   const responsePost = await server.inject({
     method: 'POST',
@@ -1045,9 +989,7 @@ test('GET /styles/:styleId when style exists returns style with sources pointing
 })
 
 test('GET /styles when no styles exist returns body with an empty array', async (t) => {
-  const { server } = createContext()
-
-  t.teardown(() => server.close())
+  const { server } = createContext(t)
 
   const response = await server.inject({ method: 'GET', url: '/styles' })
 
@@ -1057,9 +999,7 @@ test('GET /styles when no styles exist returns body with an empty array', async 
 })
 
 test('GET /styles when styles exist returns array of metadata for each', async (t) => {
-  const { server, sampleStyleJSON } = createContext()
-
-  t.teardown(() => server.close())
+  const { server, sampleStyleJSON } = createContext(t)
 
   const expectedName = 'My Style'
 
@@ -1096,9 +1036,7 @@ test('GET /styles when styles exist returns array of metadata for each', async (
 })
 
 test('DELETE /styles/:styleId when style does not exist returns 404 status code', async (t) => {
-  const { server } = createContext()
-
-  t.teardown(() => server.close())
+  const { server } = createContext(t)
 
   const id = 'nonexistent-id'
 
@@ -1111,9 +1049,7 @@ test('DELETE /styles/:styleId when style does not exist returns 404 status code'
 })
 
 test('DELETE /styles/:styleId when style exists returns 204 status code and empty body', async (t) => {
-  const { server } = createContext()
-
-  t.teardown(() => server.close())
+  const { server } = createContext(t)
 
   const responsePost = await server.inject({
     method: 'POST',
@@ -1146,9 +1082,7 @@ test('DELETE /styles/:styleId when style exists returns 204 status code and empt
 test('DELETE /styles/:styleId works for style created from tileset import', async (t) => {
   t.plan(3)
 
-  const { sampleMbTilesPath, server } = createContext()
-
-  t.teardown(() => server.close())
+  const { sampleMbTilesPath, server } = createContext(t)
 
   const importResponse = await server.inject({
     method: 'POST',

--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -82,7 +82,6 @@ function createContext() {
   const server = createServer()
 
   const context = {
-    cleanup: (s = server) => s.close(),
     createServer,
     server,
     sampleMbTilesPath: mbTilesPath,
@@ -118,7 +117,9 @@ async function waitForImportCompletion(endpoint: string) {
  */
 
 test('GET /tilesets when no tilesets exist returns an empty array', async (t) => {
-  const { server, cleanup } = createContext()
+  const { server } = createContext()
+
+  t.teardown(() => server.close())
 
   const response = await server.inject({ method: 'GET', url: '/tilesets' })
 
@@ -131,12 +132,12 @@ test('GET /tilesets when no tilesets exist returns an empty array', async (t) =>
   )
 
   t.same(response.json(), [])
-
-  return cleanup()
 })
 
 test('GET /tilesets when tilesets exist returns an array of the tilesets', async (t) => {
-  const { cleanup, sampleTileJSON, server } = createContext()
+  const { sampleTileJSON, server } = createContext()
+
+  t.teardown(() => server.close())
 
   await server.inject({
     method: 'POST',
@@ -157,12 +158,12 @@ test('GET /tilesets when tilesets exist returns an array of the tilesets', async
   const response = await server.inject({ method: 'GET', url: '/tilesets' })
 
   t.same(response.json(), expectedResponse)
-
-  return cleanup()
 })
 
 test('POST /tilesets when tileset does not exist creates a tileset and returns it', async (t) => {
-  const { cleanup, sampleTileJSON, server } = createContext()
+  const { sampleTileJSON, server } = createContext()
+
+  t.teardown(() => server.close())
 
   const expectedId = '23z3tmtw49abd8b4ycah9x94ykjhedam'
   const expectedTileUrl = `http://localhost:80/tilesets/${expectedId}/{z}/{x}/{y}`
@@ -187,12 +188,12 @@ test('POST /tilesets when tileset does not exist creates a tileset and returns i
   })
 
   t.equal(responseGet.statusCode, 200)
-
-  return cleanup()
 })
 
 test('POST /tilesets creates a style for the raster tileset', async (t) => {
-  const { cleanup, sampleTileJSON, server } = createContext()
+  const { sampleTileJSON, server } = createContext()
+
+  t.teardown(() => server.close())
 
   const responseTilesetsPost = await server.inject({
     method: 'POST',
@@ -240,12 +241,12 @@ test('POST /tilesets creates a style for the raster tileset', async (t) => {
   }
 
   t.same(responseStyleGet.json(), expectedStyle)
-
-  return cleanup()
 })
 
 test('PUT /tilesets when tileset exists returns the updated tileset', async (t) => {
-  const { cleanup, sampleTileJSON, server } = createContext()
+  const { sampleTileJSON, server } = createContext()
+
+  t.teardown(() => server.close())
 
   const initialResponse = await server.inject({
     method: 'POST',
@@ -268,12 +269,12 @@ test('PUT /tilesets when tileset exists returns the updated tileset', async (t) 
   t.notSame(initialResponse.json(), updatedResponse.json())
 
   t.equal(updatedResponse.json<TileJSON>().name, updatedFields.name)
-
-  return cleanup()
 })
 
 test('PUT /tilesets when providing an incorrect id returns 400 status code', async (t) => {
-  const { cleanup, sampleTileJSON, server } = createContext()
+  const { sampleTileJSON, server } = createContext()
+
+  t.teardown(() => server.close())
 
   const response = await server.inject({
     method: 'PUT',
@@ -282,12 +283,12 @@ test('PUT /tilesets when providing an incorrect id returns 400 status code', asy
   })
 
   t.equal(response.statusCode, 400)
-
-  return cleanup()
 })
 
 test('PUT /tilesets when tileset does not exist returns 404 status code', async (t) => {
-  const { cleanup, sampleTileJSON, server } = createContext()
+  const { sampleTileJSON, server } = createContext()
+
+  t.teardown(() => server.close())
 
   const response = await server.inject({
     method: 'PUT',
@@ -296,8 +297,6 @@ test('PUT /tilesets when tileset does not exist returns 404 status code', async 
   })
 
   t.equal(response.statusCode, 404)
-
-  return cleanup()
 })
 
 /**
@@ -305,7 +304,9 @@ test('PUT /tilesets when tileset does not exist returns 404 status code', async 
  */
 
 test('GET /tile before tileset is created returns 404 status code', async (t) => {
-  const { cleanup, server } = createContext()
+  const { server } = createContext()
+
+  t.teardown(() => server.close())
 
   const response = await server.inject({
     method: 'GET',
@@ -313,12 +314,12 @@ test('GET /tile before tileset is created returns 404 status code', async (t) =>
   })
 
   t.equal(response.statusCode, 404)
-
-  return cleanup()
 })
 
 test('GET /tile of png format returns a tile image', async (t) => {
-  const { cleanup, sampleTileJSON, server } = createContext()
+  const { sampleTileJSON, server } = createContext()
+
+  t.teardown(() => server.close())
 
   // Create initial tileset
   const initialResponse = await server.inject({
@@ -343,12 +344,12 @@ test('GET /tile of png format returns a tile image', async (t) => {
   )
 
   t.equal(typeof response.body, 'string')
-
-  return cleanup()
 })
 
 test('POST /tilesets/import fails when providing path for non-existent file', async (t) => {
-  const { cleanup, server } = createContext()
+  const { server } = createContext()
+
+  t.teardown(() => server.close())
 
   const importResponse = await server.inject({
     method: 'POST',
@@ -358,12 +359,12 @@ test('POST /tilesets/import fails when providing path for non-existent file', as
 
   t.equal(importResponse.statusCode, 400)
   t.equal(importResponse.json().code, 'FST_MBTILES_IMPORT_TARGET_MISSING')
-
-  return cleanup()
 })
 
 test('POST /tilesets/import fails when provided vector tiles format', async (t) => {
-  const { cleanup, server } = createContext()
+  const { server } = createContext()
+
+  t.teardown(() => server.close())
 
   const unsupportedFixturePath = path.resolve(
     __dirname,
@@ -381,12 +382,12 @@ test('POST /tilesets/import fails when provided vector tiles format', async (t) 
   t.equal(importResponse.statusCode, 400)
 
   t.equal(importResponse.json().code, 'FST_UNSUPPORTED_MBTILES_FORMAT')
-
-  cleanup()
 })
 
 test('POST /tilesets/import creates tileset', async (t) => {
-  const { cleanup, sampleMbTilesPath, server } = createContext()
+  const { sampleMbTilesPath, server } = createContext()
+
+  t.teardown(() => server.close())
 
   const importResponse = await server.inject({
     method: 'POST',
@@ -406,12 +407,12 @@ test('POST /tilesets/import creates tileset', async (t) => {
   t.equal(tilesetGetResponse.statusCode, 200)
 
   t.same(tilesetGetResponse.json(), createdTileset)
-
-  return cleanup()
 })
 
 test('POST /tilesets/import creates style for created tileset', async (t) => {
-  const { cleanup, sampleMbTilesPath, server } = createContext()
+  const { sampleMbTilesPath, server } = createContext()
+
+  t.teardown(() => server.close())
 
   const importResponse = await server.inject({
     method: 'POST',
@@ -457,14 +458,14 @@ test('POST /tilesets/import creates style for created tileset', async (t) => {
     styleHasSourceReferringToTileset,
     'style has source pointing to correct tileset'
   )
-
-  return cleanup()
 })
 
 test('POST /tilesets/import multiple times using same source file works', async (t) => {
   t.plan(5)
 
-  const { cleanup, sampleMbTilesPath, server } = createContext()
+  const { sampleMbTilesPath, server } = createContext()
+
+  t.teardown(() => server.close())
 
   async function requestImport() {
     return await server.inject({
@@ -509,12 +510,12 @@ test('POST /tilesets/import multiple times using same source file works', async 
   t.equal(tilesetGetResponse2.statusCode, 200)
 
   t.notEqual(importId1, importId2, 'new import is created')
-
-  return cleanup()
 })
 
 test('POST /tilesets/import storage used by tiles is roughly equivalent to that of source', async (t) => {
-  const { cleanup, sampleMbTilesPath, server } = createContext()
+  const { sampleMbTilesPath, server } = createContext()
+
+  t.teardown(() => server.close())
 
   function getMbTilesByteCount() {
     const mbTilesDb = new Database(sampleMbTilesPath, { readonly: true })
@@ -560,13 +561,13 @@ test('POST /tilesets/import storage used by tiles is roughly equivalent to that 
     bytesStored >= roughlyExpectedCount * minimumProportion &&
       bytesStored <= roughlyExpectedCount
   )
-
-  return cleanup()
 })
 
 // TODO: This may eventually become a failing test if styles that share tiles reuse new ones that are stored
 test('POST /tilesets/import subsequent imports do not affect storage calculation for existing styles', async (t) => {
-  const { cleanup, sampleMbTilesPath, server } = createContext()
+  const { sampleMbTilesPath, server } = createContext()
+
+  t.teardown(() => server.close())
 
   const address = await server.listen(0)
 
@@ -609,8 +610,6 @@ test('POST /tilesets/import subsequent imports do not affect storage calculation
     )
 
   t.equal(style1Before.bytesStored, style1After.bytesStored)
-
-  return cleanup()
 })
 
 /**
@@ -618,7 +617,9 @@ test('POST /tilesets/import subsequent imports do not affect storage calculation
  */
 
 test('GET /imports/:importId returns 404 error when import does not exist', async (t) => {
-  const { cleanup, server } = createContext()
+  const { server } = createContext()
+
+  t.teardown(() => server.close())
 
   const getImportInfoResponse = await server.inject({
     method: 'GET',
@@ -626,12 +627,12 @@ test('GET /imports/:importId returns 404 error when import does not exist', asyn
   })
 
   t.equal(getImportInfoResponse.statusCode, 404)
-
-  return cleanup()
 })
 
 test('GET /imports/progress/:importId returns 404 error when import does not exist', async (t) => {
-  const { cleanup, server } = createContext()
+  const { server } = createContext()
+
+  t.teardown(() => server.close())
 
   const address = await server.listen(0)
 
@@ -646,12 +647,12 @@ test('GET /imports/progress/:importId returns 404 error when import does not exi
 
   // @ts-ignore
   t.equal(error?.status, 404)
-
-  return cleanup()
 })
 
 test('GET /imports/:importId returns import information', async (t) => {
-  const { cleanup, sampleMbTilesPath, server } = createContext()
+  const { sampleMbTilesPath, server } = createContext()
+
+  t.teardown(() => server.close())
 
   const createImportResponse = await server.inject({
     method: 'POST',
@@ -671,14 +672,14 @@ test('GET /imports/:importId returns import information', async (t) => {
   })
 
   t.equal(getImportInfoResponse.statusCode, 200)
-
-  return cleanup()
 })
 
 test('GET /imports/progress/:importId returns import progress info (SSE)', async (t) => {
   t.plan(5)
 
-  const { cleanup, sampleMbTilesPath, server } = createContext()
+  const { sampleMbTilesPath, server } = createContext()
+
+  t.teardown(() => server.close())
 
   const createImportResponse = await server.inject({
     method: 'POST',
@@ -759,14 +760,14 @@ test('GET /imports/progress/:importId returns import progress info (SSE)', async
       t.fail(err.message)
     }
   }
-
-  return cleanup()
 })
 
 test('GET /imports/progress/:importId when import is already completed returns single complete event (SSE)', async (t) => {
   t.plan(1)
 
-  const { cleanup, sampleMbTilesPath, server } = createContext()
+  const { sampleMbTilesPath, server } = createContext()
+
+  t.teardown(() => server.close())
 
   const createImportResponse = await server.inject({
     method: 'POST',
@@ -801,17 +802,12 @@ test('GET /imports/progress/:importId when import is already completed returns s
   })
 
   t.same(message, expectedMessage)
-
-  return cleanup()
 })
 
 test('GET /imports/:importId on failed import returns import with error state', async (t) => {
-  const {
-    cleanup,
-    createServer,
-    sampleMbTilesPath,
-    server: server1,
-  } = createContext()
+  const { createServer, sampleMbTilesPath, server: server1 } = createContext()
+
+  t.teardown(() => server1.close())
 
   const createImportResponse = await server1.inject({
     method: 'POST',
@@ -830,6 +826,8 @@ test('GET /imports/:importId on failed import returns import with error state', 
 
   const server2 = createServer()
 
+  t.teardown(() => server2.close())
+
   const getImportResponse = await server2.inject({
     method: 'GET',
     url: `/imports/${createdImportId}`,
@@ -842,15 +840,15 @@ test('GET /imports/:importId on failed import returns import with error state', 
   t.equal(impt.state, 'error')
   t.equal(impt.error, 'UNKNOWN')
   t.ok(impt.finished)
-
-  return cleanup(server2)
 })
 
 // TODO: Add styles tests for:
 // - POST /styles (style via url)
 
 test('POST /styles with invalid style returns 400 status code', async (t) => {
-  const { cleanup, server, sampleStyleJSON } = createContext()
+  const { server, sampleStyleJSON } = createContext()
+
+  t.teardown(() => server.close())
 
   const responsePost = await server.inject({
     method: 'POST',
@@ -859,14 +857,14 @@ test('POST /styles with invalid style returns 400 status code', async (t) => {
   })
 
   t.equal(responsePost.statusCode, 400)
-
-  return cleanup()
 })
 
 // Reflects the case where a user is providing the style directly
 // We'd enforce at the application level that they provide an `id` field in their body
 test('POST /styles when providing an id returns resource with the same id', async (t) => {
-  const { cleanup, server, sampleStyleJSON } = createContext()
+  const { server, sampleStyleJSON } = createContext()
+
+  t.teardown(() => server.close())
 
   const expectedId = 'example-style-id'
 
@@ -883,12 +881,12 @@ test('POST /styles when providing an id returns resource with the same id', asyn
   })
 
   t.equal(responsePost.json().id, expectedId)
-
-  return cleanup()
 })
 
 test('POST /styles when style exists returns 409', async (t) => {
-  const { cleanup, server, sampleStyleJSON } = createContext()
+  const { server, sampleStyleJSON } = createContext()
+
+  t.teardown(() => server.close())
 
   const payload = {
     style: sampleStyleJSON,
@@ -911,12 +909,12 @@ test('POST /styles when style exists returns 409', async (t) => {
   })
 
   t.equal(responsePost2.statusCode, 409)
-
-  return cleanup()
 })
 
 test('POST /styles when providing valid style returns resource with id and altered style', async (t) => {
-  const { cleanup, server, sampleStyleJSON } = createContext()
+  const { server, sampleStyleJSON } = createContext()
+
+  t.teardown(() => server.close())
 
   const responsePost = await server.inject({
     method: 'POST',
@@ -973,12 +971,12 @@ test('POST /styles when providing valid style returns resource with id and alter
       'with exception of `url` field, source from created style matches source from input'
     )
   })
-
-  return cleanup()
 })
 
 test('POST /styles when required Mapbox access token is missing returns 400 status code', async (t) => {
-  const { cleanup, server, sampleStyleJSON } = createContext()
+  const { server, sampleStyleJSON } = createContext()
+
+  t.teardown(() => server.close())
 
   const responsePost = await server.inject({
     method: 'POST',
@@ -988,12 +986,12 @@ test('POST /styles when required Mapbox access token is missing returns 400 stat
   })
 
   t.equal(responsePost.statusCode, 400)
-
-  return cleanup()
 })
 
 test('GET /styles/:styleId when style does not exist return 404 status code', async (t) => {
-  const { cleanup, server } = createContext()
+  const { server } = createContext()
+
+  t.teardown(() => server.close())
 
   const id = 'nonexistent-id'
 
@@ -1003,12 +1001,12 @@ test('GET /styles/:styleId when style does not exist return 404 status code', as
   })
 
   t.equal(responseGet.statusCode, 404)
-
-  return cleanup()
 })
 
 test('GET /styles/:styleId when style exists returns style with sources pointing to offline tilesets', async (t) => {
-  const { cleanup, server, sampleStyleJSON } = createContext()
+  const { server, sampleStyleJSON } = createContext()
+
+  t.teardown(() => server.close())
 
   const responsePost = await server.inject({
     method: 'POST',
@@ -1044,24 +1042,24 @@ test('GET /styles/:styleId when style exists returns style with sources pointing
       t.equal(responseTilesetGet.statusCode, 200)
     }
   }
-
-  return cleanup()
 })
 
 test('GET /styles when no styles exist returns body with an empty array', async (t) => {
-  const { cleanup, server } = createContext()
+  const { server } = createContext()
+
+  t.teardown(() => server.close())
 
   const response = await server.inject({ method: 'GET', url: '/styles' })
 
   t.equal(response.statusCode, 200)
 
   t.same(response.json(), [])
-
-  return cleanup()
 })
 
 test('GET /styles when styles exist returns array of metadata for each', async (t) => {
-  const { cleanup, server, sampleStyleJSON } = createContext()
+  const { server, sampleStyleJSON } = createContext()
+
+  t.teardown(() => server.close())
 
   const expectedName = 'My Style'
 
@@ -1095,12 +1093,12 @@ test('GET /styles when styles exist returns array of metadata for each', async (
   t.equal(responseGet.statusCode, 200)
 
   t.same(responseGet.json(), expectedGetResponse)
-
-  return cleanup()
 })
 
 test('DELETE /styles/:styleId when style does not exist returns 404 status code', async (t) => {
-  const { cleanup, server } = createContext()
+  const { server } = createContext()
+
+  t.teardown(() => server.close())
 
   const id = 'nonexistent-id'
 
@@ -1110,12 +1108,12 @@ test('DELETE /styles/:styleId when style does not exist returns 404 status code'
   })
 
   t.equal(responseDelete.statusCode, 404)
-
-  return cleanup()
 })
 
 test('DELETE /styles/:styleId when style exists returns 204 status code and empty body', async (t) => {
-  const { cleanup, server } = createContext()
+  const { server } = createContext()
+
+  t.teardown(() => server.close())
 
   const responsePost = await server.inject({
     method: 'POST',
@@ -1143,14 +1141,14 @@ test('DELETE /styles/:styleId when style exists returns 204 status code and empt
   })
 
   t.equal(responseGet.statusCode, 404, 'style is properly deleted')
-
-  return cleanup()
 })
 
 test('DELETE /styles/:styleId works for style created from tileset import', async (t) => {
   t.plan(3)
 
-  const { cleanup, sampleMbTilesPath, server } = createContext()
+  const { sampleMbTilesPath, server } = createContext()
+
+  t.teardown(() => server.close())
 
   const importResponse = await server.inject({
     method: 'POST',
@@ -1211,6 +1209,4 @@ test('DELETE /styles/:styleId works for style created from tileset import', asyn
   })
 
   t.equal(responseGet.statusCode, 404, 'style is properly deleted')
-
-  return cleanup()
 })

--- a/src/lib/upstream_requests_manager.test.ts
+++ b/src/lib/upstream_requests_manager.test.ts
@@ -47,7 +47,6 @@ async function createContext() {
   return {
     server,
     upstreamRequestsManager: new UpstreamRequestsManager(),
-    cleanup: async () => server.close(),
   }
 }
 
@@ -58,7 +57,9 @@ async function createContext() {
  * 3. Manager does not make additional requests, fulfills with existing request
  */
 test('Repeat requests in same tick only hit server once', async (t) => {
-  const { cleanup, server, upstreamRequestsManager } = await createContext()
+  const { server, upstreamRequestsManager } = await createContext()
+
+  t.teardown(() => server.close())
 
   const responses = await Promise.all([
     upstreamRequestsManager.getUpstream({
@@ -85,8 +86,6 @@ test('Repeat requests in same tick only hit server once', async (t) => {
   await upstreamRequestsManager.allSettled()
 
   t.equal(server.responses.length, 1, 'Only one request to server')
-
-  return cleanup()
 })
 
 /**
@@ -97,7 +96,9 @@ test('Repeat requests in same tick only hit server once', async (t) => {
  * 5. Client make subsequent request for resource *based on resource from step 1*. Response should reflect updated resource
  */
 test('Upstream resource updated when modified', async (t) => {
-  const { cleanup, server, upstreamRequestsManager } = await createContext()
+  const { server, upstreamRequestsManager } = await createContext()
+
+  t.teardown(() => server.close())
 
   const response1 = await upstreamRequestsManager.getUpstream({
     url: ENDPOINT_URL,
@@ -156,15 +157,15 @@ test('Upstream resource updated when modified', async (t) => {
     200,
     'On third request, server responded with updated resource'
   )
-
-  return cleanup()
 })
 
 /**
  * Requesting an upstream resource that hasn't been modified should reject with a not modified error
  */
 test('Upstream resource not modified', async (t) => {
-  const { cleanup, server, upstreamRequestsManager } = await createContext()
+  const { server, upstreamRequestsManager } = await createContext()
+
+  t.teardown(() => server.close())
 
   const response1 = await upstreamRequestsManager.getUpstream({
     url: ENDPOINT_URL,
@@ -192,8 +193,6 @@ test('Upstream resource not modified', async (t) => {
     304,
     'On second request, server says not modified'
   )
-
-  return cleanup()
 })
 
 // TODO: Add tests for text and json response types

--- a/src/lib/upstream_requests_manager.test.ts
+++ b/src/lib/upstream_requests_manager.test.ts
@@ -1,6 +1,6 @@
 import Fastify from 'fastify'
 import Etag from '@fastify/etag'
-import test from 'tape'
+import test, { Test } from 'tape'
 
 import { UpstreamRequestsManager } from './upstream_requests_manager'
 
@@ -40,8 +40,11 @@ function createServer() {
   }
 }
 
-async function createContext() {
+async function createContext(t: Test) {
   const server = createServer()
+
+  t.teardown(() => server.close())
+
   await server.listen(PORT)
 
   return {
@@ -57,9 +60,7 @@ async function createContext() {
  * 3. Manager does not make additional requests, fulfills with existing request
  */
 test('Repeat requests in same tick only hit server once', async (t) => {
-  const { server, upstreamRequestsManager } = await createContext()
-
-  t.teardown(() => server.close())
+  const { server, upstreamRequestsManager } = await createContext(t)
 
   const responses = await Promise.all([
     upstreamRequestsManager.getUpstream({
@@ -96,9 +97,7 @@ test('Repeat requests in same tick only hit server once', async (t) => {
  * 5. Client make subsequent request for resource *based on resource from step 1*. Response should reflect updated resource
  */
 test('Upstream resource updated when modified', async (t) => {
-  const { server, upstreamRequestsManager } = await createContext()
-
-  t.teardown(() => server.close())
+  const { server, upstreamRequestsManager } = await createContext(t)
 
   const response1 = await upstreamRequestsManager.getUpstream({
     url: ENDPOINT_URL,
@@ -163,9 +162,7 @@ test('Upstream resource updated when modified', async (t) => {
  * Requesting an upstream resource that hasn't been modified should reject with a not modified error
  */
 test('Upstream resource not modified', async (t) => {
-  const { server, upstreamRequestsManager } = await createContext()
-
-  t.teardown(() => server.close())
+  const { server, upstreamRequestsManager } = await createContext(t)
 
   const response1 = await upstreamRequestsManager.getUpstream({
     url: ENDPOINT_URL,


### PR DESCRIPTION
didn't really occur to me until now that we should be using tape's `teardown` for closing server instances in tests. previously, we called `cleanup` at the end of a test but that doesn't handle the case of when uncaught exceptions occur within a test, which will cause the server to never close and the test to hang.