### PR TITLE
fix: Fix v8 error with graceful onClose cleanup

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -1247,6 +1247,7 @@ function init(dbPath: string): Context {
 
   const piscina = new Piscina({
     filename: path.resolve(__dirname, './lib/mbtiles_import_worker.js'),
+    minThreads: 1,
   })
   piscina.on('error', (error) => {
     // TODO: Do something with this error https://github.com/piscinajs/piscina#event-error

--- a/src/api.ts
+++ b/src/api.ts
@@ -1210,6 +1210,20 @@ const ApiPlugin: FastifyPluginAsync<MapServerOptions> = async (
 
   fastify.addHook('onClose', async () => {
     const { piscina, db } = context
+    if (context.activeImports.size > 0) {
+      // Wait for all worker threads to finish, so we don't terminate the thread
+      // without closing the DB connections in thread. This is kind-of hacky:
+      // It relies on the MessagePort being closed when the worker thread is done.
+      await Promise.all(
+        [...context.activeImports.values()].map(
+          (port) =>
+            new Promise((res) => {
+              port.once('close', res)
+              port.once('error', res)
+            })
+        )
+      )
+    }
     await piscina.destroy()
     db.close()
   })


### PR DESCRIPTION
Seems like the cause of the v8 error we were getting (https://github.com/WiseLibs/better-sqlite3/issues/842) might have been caused by terminating the worker threads without first closing the DB instance. This PR attempts to fix that by doing a graceful shutdown of workers (it waits for them to finish) before closing the server completely. This PR also adds the `minThreads: 1` option to Piscina, since otherwise I think Piscina opens a worker thread for every CPU available on startup. This minimizes the initial overhead of thread creation. 