### PR TITLE
feat: HTML map previews

### DIFF
--- a/src/public/map_preview.html
+++ b/src/public/map_preview.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Mapserver Map Preview</title>
+    <meta
+      name="viewport"
+      content="initial-scale=1,maximum-scale=1,user-scalable=no"
+    />
+    <link
+      href="https://api.mapbox.com/mapbox-gl-js/v2.9.2/mapbox-gl.css"
+      rel="stylesheet"
+    />
+    <script src="https://api.mapbox.com/mapbox-gl-js/v2.9.2/mapbox-gl.js"></script>
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      #map {
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        width: 100%;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="map"></div>
+    <script>
+      const styleUrl = window.location.href.replace('/preview', '')
+      mapboxgl.accessToken =
+        'pk.eyJ1IjoiZGlnaWRlbSIsImEiOiJjbDZreWF1d28wMnE0M2Jta3dpMWsyY2M3In0.9TzErzHgMJ6jVCq_bbMXZA'
+      const map = new mapboxgl.Map({
+        container: 'map',
+        style: styleUrl,
+      })
+    </script>
+  </body>
+</html>

--- a/src/routes/styles.ts
+++ b/src/routes/styles.ts
@@ -2,6 +2,7 @@ import { FastifyPluginAsync } from 'fastify'
 import createError from '@fastify/error'
 import got from 'got'
 import { Static, Type as T } from '@sinclair/typebox'
+import path from 'path'
 
 import { normalizeStyleURL } from '../lib/mapbox_urls'
 import { StyleJSON, createIdFromStyleUrl, validate } from '../lib/stylejson'
@@ -166,6 +167,14 @@ const styles: FastifyPluginAsync = async function (fastify) {
     Reply: StyleJSON
   }>('/:id', async function (request) {
     return this.api.getStyle(request.params.id, getBaseApiUrl(request))
+  })
+
+  fastify.get<{
+    Params: {
+      id: string
+    }
+  }>('/:id/preview', function (request, reply) {
+    reply.sendFile('map_preview.html', path.join(__dirname, '../public'))
   })
 
   fastify.delete<{


### PR DESCRIPTION
A very quick implementation that enables viewing of a map preview rendered with mapbox-gl-js. Append `/preview` to a Style URL to view that style rendered in the browser. Mainly useful for development.

Built on #54 since it uses fastify-static and that's already in #54.