### PR TITLE
fix: remove stray style and tileset when import fails to start

### DIFF
--- a/src/api/errors.ts
+++ b/src/api/errors.ts
@@ -52,6 +52,12 @@ export const MBTilesInvalidMetadataError = createError(
   400
 )
 
+export const MBTilesCannotReadError = createError(
+  'FST_MBTILES_CANNOT_READ',
+  'mbtiles file could not be read properly: %s',
+  400
+)
+
 export const UpstreamJsonValidationError = createError(
   'FST_UPSTREAM_VALIDATION',
   'JSON validation failed for upstream resource from %s: %s',

--- a/src/api/imports.ts
+++ b/src/api/imports.ts
@@ -14,6 +14,7 @@ import {
 import { generateId, getTilesetId } from '../lib/utils'
 import { Api, Context, IdResource } from '.'
 import {
+  MBTilesCannotReadError,
   MBTilesImportTargetMissingError,
   MBTilesInvalidMetadataError,
   NotFoundError,
@@ -33,7 +34,7 @@ function createImportsApi({
   api,
   context,
 }: {
-  api: Pick<Api, 'createStyleForTileset' | 'createTileset'>
+  api: Pick<Api, 'createStyleForTileset' | 'createTileset' | 'deleteStyle'>
   context: Context
 }): ImportsApi {
   const { activeImports, db, piscina } = context
@@ -105,6 +106,7 @@ function createImportsApi({
       activeImports.set(importId, port2)
 
       return new Promise((res, rej) => {
+        let importStarted = false
         let workerDone = false
         // Initially use a longer duration to account for worker startup
         let timeoutId = createTimeout(10000)
@@ -130,8 +132,17 @@ function createImportsApi({
             { signal: abortSignaler, transferList: [port1] }
           )
           .catch((err) => {
+            if (!importStarted) {
+              api.deleteStyle(styleId, baseApiUrl)
+            }
+
+            // If a sqlite error is raised and the import has not started
+            // we assume that there is an issue reading the mbtiles file provided
+            const isMbTilesIssue =
+              err?.code.startsWith('SQLITE') && !importStarted
+
             // FYI this will be called when piscina.destroy() in the onClose hook
-            rej(err)
+            rej(isMbTilesIssue ? new MBTilesCannotReadError(err.code) : err)
           })
           .finally(() => {
             cleanup()
@@ -140,6 +151,7 @@ function createImportsApi({
 
         function handleFirstProgressMessage(message: PortMessage) {
           if (message.type === 'progress') {
+            importStarted = true
             port2.off('message', handleFirstProgressMessage)
             res({ import: { id: message.importId }, tileset })
           }
@@ -160,9 +172,13 @@ function createImportsApi({
           abortSignaler.emit('abort')
 
           try {
-            db.prepare(
-              "UPDATE Import SET state = 'error', finished = CURRENT_TIMESTAMP, error = 'TIMEOUT' WHERE id = ?"
-            ).run(importId)
+            if (importStarted) {
+              db.prepare(
+                "UPDATE Import SET state = 'error', finished = CURRENT_TIMESTAMP, error = 'TIMEOUT' WHERE id = ?"
+              ).run(importId)
+            } else {
+              api.deleteStyle(styleId, baseApiUrl)
+            }
           } catch (err) {
             // TODO: This could potentially throw when the db is closed already. Need to properly handle/report
             console.error(err)

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -53,6 +53,7 @@ function createApi(context: Context): Api {
     api: {
       createTileset: tilesetsApi.createTileset,
       createStyleForTileset: stylesApi.createStyleForTileset,
+      deleteStyle: stylesApi.deleteStyle,
     },
     context,
   })

--- a/test/e2e/tilesets-import.test.js
+++ b/test/e2e/tilesets-import.test.js
@@ -259,8 +259,7 @@ test('POST /tilesets/import subsequent imports do not affect storage calculation
   t.equal(style1Before.bytesStored, style1After.bytesStored)
 })
 
-// Failing test
-test.skip('POST /tilesets/import fails when providing invalid mbtiles, no tilesets or styles created', async (t) => {
+test('POST /tilesets/import fails when providing invalid mbtiles, no tilesets or styles created', async (t) => {
   const server = createServer(t)
   const badMbTilesPath = path.join(
     fixturesPath,
@@ -272,7 +271,6 @@ test.skip('POST /tilesets/import fails when providing invalid mbtiles, no tilese
     payload: { filePath: badMbTilesPath },
   })
 
-  // This is currently 500, but should probably be 400?
   t.equal(importResponse.statusCode, 400)
 
   const tilesetsRes = await server.inject({ method: 'GET', url: '/tilesets' })


### PR DESCRIPTION
Closes #58 

Notes:

- Went with a naive approach of deleting the style (which deletes the associated tileset) if the import fails to start. Ideally we'd prevent them from being created in the first place, but would likely entail some messy coordination of messages