### PR TITLE
fix: use mbtiles file name as fallback style name when importing as new tileset

### DIFF
--- a/src/api/imports.ts
+++ b/src/api/imports.ts
@@ -88,7 +88,9 @@ function createImportsApi({
 
       const tileset = api.createTileset(tilejson, baseApiUrl)
 
-      const { id: styleId } = api.createStyleForTileset(tileset, tileset.name)
+      const styleName = tileset.name || path.basename(filePath, '.mbtiles')
+
+      const { id: styleId } = api.createStyleForTileset(tileset, styleName)
 
       const importId = generateId()
 

--- a/src/api/styles.ts
+++ b/src/api/styles.ts
@@ -292,6 +292,7 @@ function createStylesApi({
 
       const sourceIdToTilesetId: { [sourceId: string]: string } = {}
 
+      // In this case, the style will only have 1 source
       Object.keys(style.sources).forEach((sourceId) => {
         sourceIdToTilesetId[sourceId] = tilesetId
       })

--- a/test/e2e/tilesets-import.test.js
+++ b/test/e2e/tilesets-import.test.js
@@ -157,17 +157,13 @@ test('POST /tilesets/import creates style for created tileset', async (t) => {
 
     const style = styleGetResponse.json()
 
-    const containsSourcePointingToTileset = Object.values(style.sources).some(
-      (source) => {
-        if ('url' in source && source.url) {
-          return source.url === expectedSourceUrl
-        }
-        return false
-      }
-    )
+    const sources = Object.values(style.sources)
 
-    t.ok(
-      containsSourcePointingToTileset,
+    t.equal(sources.length, 1, 'style has one source')
+
+    t.equal(
+      sources[0].url,
+      expectedSourceUrl,
       'style has source pointing to correct tileset'
     )
 


### PR DESCRIPTION
Addresses feedback from https://github.com/digidem/mapeo-map-server/pull/56#discussion_r942860866

Also includes other smaller unrelated chores from that previous PR