### PR TITLE
fix: return proper responses for get tile endpoint

### DIFF
--- a/src/api/errors.ts
+++ b/src/api/errors.ts
@@ -1,4 +1,5 @@
 import createError from '@fastify/error'
+import { HTTPError, RequestError } from 'got'
 
 // TODO: Probably not the safest to use ENOTFOUND to indicate no internet access
 export const OFFLINE_ERROR_CODES = ['ENOTFOUND', 'ENETUNREACH']
@@ -82,3 +83,14 @@ export const createForwardedUpstreamError = (statusCode: number) =>
     'Upstream request at %s responded with: %s',
     statusCode
   )
+
+export function isOfflineError(err: unknown): err is RequestError {
+  return err instanceof RequestError && OFFLINE_ERROR_CODES.includes(err.code)
+}
+
+export function isNotFoundError(err: unknown) {
+  return (
+    err instanceof NotFoundError ||
+    (err instanceof HTTPError && err.response.statusCode === 404)
+  )
+}

--- a/src/api/errors.ts
+++ b/src/api/errors.ts
@@ -79,8 +79,8 @@ export const InvalidGlyphsRangeError = createError(
 
 export const createForwardedUpstreamError = (statusCode: number) =>
   createError(
-    `FORWARDED_UPSTREAM_${statusCode}`,
-    'Upstream request at %s responded with: %s',
+    `FST_FORWARDED_UPSTREAM`,
+    'Request to %s errored with: %s',
     statusCode
   )
 

--- a/src/api/tiles.ts
+++ b/src/api/tiles.ts
@@ -63,12 +63,7 @@ function createTilesApi({
   > {
     const upstreamTileUrl = createUpstreamTileUrl(tileParams)
 
-    // TODO: Should we throw here instead?
     if (!upstreamTileUrl) return
-
-    // We may want to check if an access token is needed before making the request
-    // but it seems that for some external tile APIs, the access token isn't needed
-    // so we don't want to throw an error too early if that's the case
 
     const normalizedUpstreamUrl = normalizeTileURL(upstreamTileUrl)
 

--- a/src/api/tiles.ts
+++ b/src/api/tiles.ts
@@ -7,7 +7,6 @@ import {
 } from '../lib/tiles'
 import { hash, noop } from '../lib/utils'
 import { Api, Context } from '.'
-import { NotFoundError } from './errors'
 
 interface SharedTileParams {
   tilesetId: string
@@ -116,22 +115,16 @@ function createTilesApi({
           // TODO: Log error
           .catch(noop)
       } else {
-        try {
-          tile = await getUpstreamTile({ tilesetId, zoom, x, y })
+        tile = await getUpstreamTile({ tilesetId, zoom, x, y })
 
-          tilesApi.putTile({
-            tilesetId,
-            zoom,
-            x,
-            y,
-            data: tile.data,
-            etag: tile.etag,
-          })
-        } catch (err) {
-          throw new NotFoundError(
-            `Tileset id = ${tilesetId}, [${zoom}, ${x}, ${y}]`
-          )
-        }
+        tilesApi.putTile({
+          tilesetId,
+          zoom,
+          x,
+          y,
+          data: tile.data,
+          etag: tile.etag,
+        })
       }
 
       return {

--- a/src/api/tiles.ts
+++ b/src/api/tiles.ts
@@ -35,12 +35,7 @@ function createTilesApi({
 }): TilesApi {
   const { db, upstreamRequestsManager } = context
 
-  function createUpstreamTileUrl({
-    tilesetId,
-    zoom,
-    x,
-    y,
-  }: SharedTileParams & { accessToken?: string }) {
+  function createUpstreamTileUrl({ tilesetId, zoom, x, y }: SharedTileParams) {
     const { tilejson, upstreamTileUrls } = api.getTilesetInfo(tilesetId)
 
     if (!upstreamTileUrls) return

--- a/src/api/tilesets.ts
+++ b/src/api/tilesets.ts
@@ -3,7 +3,7 @@ import mem from 'mem'
 import QuickLRU from 'quick-lru'
 
 import { TileJSON, validateTileJSON } from '../lib/tilejson'
-import { getTilesetId } from '../lib/utils'
+import { getTilesetId, noop } from '../lib/utils'
 import { Context, IdResource } from '.'
 import {
   AlreadyExistsError,
@@ -12,8 +12,6 @@ import {
   ParseError,
   UpstreamJsonValidationError,
 } from './errors'
-
-function noop() {}
 
 export interface TilesetsApi {
   createTileset(tileset: TileJSON, baseApiUrl: string): TileJSON & IdResource

--- a/src/lib/tiles.ts
+++ b/src/lib/tiles.ts
@@ -120,21 +120,14 @@ export function getInterpolatedUpstreamTileUrl({
 
   const quadkey = tileToQuadKey({ x, y: upstreamY, zoom })
 
-  const url = new URL(
-    templateUrls[(x + upstreamY) % templateUrls.length]
-      .replace(
-        '{prefix}',
-        (x % 16).toString(16) + (upstreamY % 16).toString(16)
-      )
-      .replace('{z}', String(zoom))
-      .replace('{x}', String(x))
-      .replace('{y}', String(upstreamY))
-      .replace('{quadkey}', quadkey)
-      .replace('{bbox-epsg-3857}', bbox)
-      .replace('{ratio}', ratio ? `@${ratio}x` : '')
-  )
-
-  return url.toString()
+  return templateUrls[(x + upstreamY) % templateUrls.length]
+    .replace('{prefix}', (x % 16).toString(16) + (upstreamY % 16).toString(16))
+    .replace('{z}', String(zoom))
+    .replace('{x}', String(x))
+    .replace('{y}', String(upstreamY))
+    .replace('{quadkey}', quadkey)
+    .replace('{bbox-epsg-3857}', bbox)
+    .replace('{ratio}', ratio ? `@${ratio}x` : '')
 }
 
 function isStringArray(value: unknown): value is string[] {

--- a/src/lib/tiles.ts
+++ b/src/lib/tiles.ts
@@ -92,14 +92,12 @@ export function getInterpolatedUpstreamTileUrl({
   zoom,
   x,
   y,
-  accessToken,
 }: {
   tiles: TileJSON['tiles']
   scheme: TileJSON['scheme']
   zoom: number
   x: number
   y: number
-  accessToken?: string
 }): string | undefined {
   // TODO: Support {ratio} in template URLs, not used in mapbox-gl-js, only in
   // the mobile SDKs
@@ -135,10 +133,6 @@ export function getInterpolatedUpstreamTileUrl({
       .replace('{bbox-epsg-3857}', bbox)
       .replace('{ratio}', ratio ? `@${ratio}x` : '')
   )
-
-  if (accessToken) {
-    url.searchParams.set('access_token', accessToken)
-  }
 
   return url.toString()
 }

--- a/src/lib/tiles.ts
+++ b/src/lib/tiles.ts
@@ -92,12 +92,14 @@ export function getInterpolatedUpstreamTileUrl({
   zoom,
   x,
   y,
+  accessToken,
 }: {
   tiles: TileJSON['tiles']
   scheme: TileJSON['scheme']
   zoom: number
   x: number
   y: number
+  accessToken?: string
 }): string | undefined {
   // TODO: Support {ratio} in template URLs, not used in mapbox-gl-js, only in
   // the mobile SDKs
@@ -120,14 +122,25 @@ export function getInterpolatedUpstreamTileUrl({
 
   const quadkey = tileToQuadKey({ x, y: upstreamY, zoom })
 
-  return templateUrls[(x + upstreamY) % templateUrls.length]
-    .replace('{prefix}', (x % 16).toString(16) + (upstreamY % 16).toString(16))
-    .replace('{z}', String(zoom))
-    .replace('{x}', String(x))
-    .replace('{y}', String(upstreamY))
-    .replace('{quadkey}', quadkey)
-    .replace('{bbox-epsg-3857}', bbox)
-    .replace('{ratio}', ratio ? `@${ratio}x` : '')
+  const url = new URL(
+    templateUrls[(x + upstreamY) % templateUrls.length]
+      .replace(
+        '{prefix}',
+        (x % 16).toString(16) + (upstreamY % 16).toString(16)
+      )
+      .replace('{z}', String(zoom))
+      .replace('{x}', String(x))
+      .replace('{y}', String(upstreamY))
+      .replace('{quadkey}', quadkey)
+      .replace('{bbox-epsg-3857}', bbox)
+      .replace('{ratio}', ratio ? `@${ratio}x` : '')
+  )
+
+  if (accessToken) {
+    url.searchParams.set('access_token', accessToken)
+  }
+
+  return url.toString()
 }
 
 function isStringArray(value: unknown): value is string[] {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -52,3 +52,5 @@ export function getBaseApiUrl(request: FastifyRequest) {
   const { hostname, protocol } = request
   return `${protocol}://${hostname}`
 }
+
+export function noop() {}

--- a/src/routes/fonts.ts
+++ b/src/routes/fonts.ts
@@ -1,11 +1,11 @@
 import { FastifyPluginAsync } from 'fastify'
-import { HTTPError, RequestError } from 'got'
+import { HTTPError } from 'got'
 import { Static, Type as T } from '@sinclair/typebox'
 
 import {
-  NotFoundError,
-  OFFLINE_ERROR_CODES,
   createForwardedUpstreamError,
+  isOfflineError,
+  isNotFoundError,
 } from '../api/errors'
 import { DEFAULT_STATIC_FONT, createStaticGlyphPath } from '../lib/glyphs'
 
@@ -19,17 +19,6 @@ const GetGlyphsQuerystring = T.Object({
   access_token: T.Optional(T.String()),
   styleId: T.Optional(T.String()),
 })
-
-function isOfflineError(err: unknown) {
-  return err instanceof RequestError && OFFLINE_ERROR_CODES.includes(err.code)
-}
-
-function isNotFoundError(err: unknown) {
-  return (
-    err instanceof NotFoundError ||
-    (err instanceof HTTPError && err.response.statusCode === 404)
-  )
-}
 
 const fonts: FastifyPluginAsync = async function (fastify) {
   // TODO: This endpoint may need to mirror the fonts api errors provided by Mapbox

--- a/src/routes/fonts.ts
+++ b/src/routes/fonts.ts
@@ -76,7 +76,7 @@ const fonts: FastifyPluginAsync = async function (fastify) {
         if (err instanceof HTTPError) {
           throw new (createForwardedUpstreamError(err.response.statusCode))(
             err.response.url,
-            err.response.statusMessage
+            err.message
           )
         }
 

--- a/src/routes/tilesets.ts
+++ b/src/routes/tilesets.ts
@@ -21,6 +21,9 @@ const GetTileParamsSchema = T.Object({
   y: T.Number(),
 })
 
+// Clients like Mapbox will pass the access token in the querystring
+// but at the moment, we do not use it for anything since the persisted
+// upstream url will already have it included if required
 const GetTileQuerystringSchema = T.Object({
   access_token: T.Optional(T.String()),
 })
@@ -110,10 +113,7 @@ const tilesets: FastifyPluginAsync = async function (fastify) {
     },
     async function (request, reply) {
       try {
-        const { data, headers } = await this.api.getTile({
-          ...request.params,
-          accessToken: request.query.access_token,
-        })
+        const { data, headers } = await this.api.getTile(request.params)
         // Ignore Etag header from MBTiles
         reply.header('Last-Modified', headers['Last-Modified'])
         // See getTileHeaders in lib/utils.ts

--- a/test/e2e/glyphs.test.js
+++ b/test/e2e/glyphs.test.js
@@ -362,7 +362,7 @@ test(
       400,
       '400 status code forwarded'
     )
-    t.equal(getGlyphsTooManyFontsResponse.json().code, 'FORWARDED_UPSTREAM_400')
+    t.equal(getGlyphsTooManyFontsResponse.json().code, 'FST_FORWARDED_UPSTREAM')
 
     const getGlyphsUnauthorizedResponse = await server.inject({
       method: 'GET',
@@ -382,7 +382,7 @@ test(
       403,
       '403 status code forwarded'
     )
-    t.equal(getGlyphsUnauthorizedResponse.json().code, 'FORWARDED_UPSTREAM_403')
+    t.equal(getGlyphsUnauthorizedResponse.json().code, 'FST_FORWARDED_UPSTREAM')
 
     t.ok(mockedGlyphsScope.isDone(), 'upstream glyphs requests were made')
   }

--- a/test/e2e/glyphs.test.js
+++ b/test/e2e/glyphs.test.js
@@ -2,6 +2,7 @@ const test = require('tape')
 const nock = require('nock')
 
 const sampleStyleJSON = require('../fixtures/good-stylejson/good-simple-raster.json')
+const { DUMMY_MB_ACCESS_TOKEN } = require('../test-helpers/constants')
 const createServer = require('../test-helpers/create-server')
 const {
   defaultMockHeaders,
@@ -10,8 +11,6 @@ const {
 } = require('../test-helpers/server-mocks')
 // This disables upstream requests (e.g. simulates offline)
 require('../test-helpers/server-mocks')
-
-const DUMMY_MB_ACCESS_TOKEN = 'pk.abc123'
 
 // Nonideal proxy to identify what a response sends back
 const OPEN_SANS_REGULAR_CONTENT_LENGTH = 74892
@@ -403,8 +402,6 @@ test(
     const expectedGlyphsUrl = `http://localhost:80/fonts/{fontstack}/{range}.pbf?styleId=${styleId}`
 
     t.equal(style.glyphs, expectedGlyphsUrl)
-
-    const mockedGlyphsScope = nock('https://api.mapbox.com/')
 
     const getGlyphsResponse = await server.inject({
       method: 'GET',

--- a/test/e2e/styles.test.js
+++ b/test/e2e/styles.test.js
@@ -2,6 +2,7 @@ const test = require('tape')
 const path = require('path')
 const nock = require('nock')
 
+const { DUMMY_MB_ACCESS_TOKEN } = require('../test-helpers/constants')
 const createServer = require('../test-helpers/create-server')
 const sampleStyleJSON = require('../fixtures/good-stylejson/good-simple-raster.json')
 const sampleTileJSON = require('../fixtures/good-tilejson/mapbox_raster_tilejson.json')
@@ -17,8 +18,6 @@ const sampleMbTilesPath = path.resolve(
   __dirname,
   '../fixtures/mbtiles/raster/countries-png.mbtiles'
 )
-
-const DUMMY_MB_ACCESS_TOKEN = 'pk.abc123'
 
 /**
  * @param {string} endpointPath

--- a/test/e2e/tilesets-crud.test.js
+++ b/test/e2e/tilesets-crud.test.js
@@ -235,7 +235,7 @@ test('GET /tile of png format returns a tile image', async (t) => {
   t.deepEqual(response.rawPayload, expectedTile, 'Got expected response')
 })
 
-test('GET /tile returns 404 response when 4XX upstream response errors occur', async (t) => {
+test('GET /tile returns 404 response when upstream returns a 4XX error', async (t) => {
   const server = createServer(t)
 
   const initialResponse = await server.inject({
@@ -253,7 +253,7 @@ test('GET /tile returns 404 response when 4XX upstream response errors occur', a
   const mockedTileScope = nock(/tiles.mapbox.com/)
     .defaultReplyHeaders(defaultMockHeaders)
     .get(upstreamTileApiRegex)
-    .reply(401, JSON.stringify({ message: 'Not Authorized - No Token' }), {
+    .reply(401, JSON.stringify('Not Authorized - No Token'), {
       'Content-Type': 'application/json',
     })
     .get(upstreamTileApiRegex)
@@ -275,6 +275,7 @@ test('GET /tile returns 404 response when 4XX upstream response errors occur', a
   })
 
   t.equal(tokenErrorResponse.statusCode, 404)
+  t.equal(tokenErrorResponse.json().code, 'FST_FORWARDED_UPSTREAM')
 
   const notFoundResponse = await server.inject({
     method: 'GET',
@@ -285,6 +286,7 @@ test('GET /tile returns 404 response when 4XX upstream response errors occur', a
   })
 
   t.equal(notFoundResponse.statusCode, 404)
+  t.equal(notFoundResponse.json().code, 'FST_FORWARDED_UPSTREAM')
 
   const unprocessableEntityResponse = await server.inject({
     method: 'GET',
@@ -295,6 +297,7 @@ test('GET /tile returns 404 response when 4XX upstream response errors occur', a
   })
 
   t.equal(unprocessableEntityResponse.statusCode, 404)
+  t.equal(unprocessableEntityResponse.json().code, 'FST_FORWARDED_UPSTREAM')
 
   t.ok(mockedTileScope.isDone(), 'tile mocks were called')
 })

--- a/test/e2e/tilesets-crud.test.js
+++ b/test/e2e/tilesets-crud.test.js
@@ -235,7 +235,7 @@ test('GET /tile of png format returns a tile image', async (t) => {
   t.deepEqual(response.rawPayload, expectedTile, 'Got expected response')
 })
 
-test('GET /tile forwards 4XX upstream response errors', async (t) => {
+test('GET /tile returns 404 response when 4XX upstream response errors occur', async (t) => {
   const server = createServer(t)
 
   const initialResponse = await server.inject({
@@ -274,16 +274,7 @@ test('GET /tile forwards 4XX upstream response errors', async (t) => {
     url: `/tilesets/${tilesetId}/1/2/3`,
   })
 
-  t.equal(
-    tokenErrorResponse.statusCode,
-    401,
-    '401 token-related response forwarded'
-  )
-  t.equal(
-    tokenErrorResponse.json().code,
-    'FORWARDED_UPSTREAM_401',
-    'response body has expected forward code'
-  )
+  t.equal(tokenErrorResponse.statusCode, 404)
 
   const notFoundResponse = await server.inject({
     method: 'GET',
@@ -293,12 +284,7 @@ test('GET /tile forwards 4XX upstream response errors', async (t) => {
     },
   })
 
-  t.equal(notFoundResponse.statusCode, 404, '404 not found response forwarded')
-  t.equal(
-    notFoundResponse.json().code,
-    'FORWARDED_UPSTREAM_404',
-    'response body has expected forward code'
-  )
+  t.equal(notFoundResponse.statusCode, 404)
 
   const unprocessableEntityResponse = await server.inject({
     method: 'GET',
@@ -308,16 +294,7 @@ test('GET /tile forwards 4XX upstream response errors', async (t) => {
     },
   })
 
-  t.equal(
-    unprocessableEntityResponse.statusCode,
-    422,
-    '422 unprocessable entity response forwarded'
-  )
-  t.equal(
-    unprocessableEntityResponse.json().code,
-    'FORWARDED_UPSTREAM_422',
-    'response body has expected forward code'
-  )
+  t.equal(unprocessableEntityResponse.statusCode, 404)
 
   t.ok(mockedTileScope.isDone(), 'tile mocks were called')
 })

--- a/test/test-helpers/constants.js
+++ b/test/test-helpers/constants.js
@@ -1,0 +1,1 @@
+module.exports = { DUMMY_MB_ACCESS_TOKEN: 'pk.abc123' }


### PR DESCRIPTION
Fixes #57 

Notes:
- Similar to the glyphs implementation, we need to forward and adjust certain responses we send based on the upstream request and internet connectivity. If a tile isn't found locally:
  - if upstream responds with 4XX, ~we forward the response~ respond with a 404
  - if upstream responds with 5XX, we respond with a 404
  - if there's no internet connectivity, we respond with a 404