### PR TITLE
fix: properly handle upstream behavior for fetching tilesets

### DIFF
--- a/src/api/styles.ts
+++ b/src/api/styles.ts
@@ -2,7 +2,6 @@ import got from 'got'
 
 import { isMapboxURL, normalizeSourceURL } from '../lib/mapbox_urls'
 import {
-  DEFAULT_RASTER_SOURCE_ID,
   StyleJSON,
   createIdFromStyleUrl,
   createRasterStyle,
@@ -10,7 +9,13 @@ import {
   uncompositeStyle,
 } from '../lib/stylejson'
 import { TileJSON, validateTileJSON } from '../lib/tilejson'
-import { encodeBase32, generateId, getTilesetId, hash } from '../lib/utils'
+import {
+  encodeBase32,
+  generateId,
+  getTilesetId,
+  hash,
+  removeSearchParams,
+} from '../lib/utils'
 import { Api, Context, IdResource } from '.'
 import {
   AlreadyExistsError,
@@ -63,7 +68,7 @@ function createStylesApi({
   api: Pick<Api, 'createTileset'>
   context: Context
 }): StylesApi {
-  const { db } = context
+  const { db, upstreamRequestsManager } = context
 
   function getStyleUrl(baseApiUrl: string, styleId: string): string {
     return `${baseApiUrl}/styles/${styleId}`
@@ -180,15 +185,24 @@ function createStylesApi({
           `Currently only sources defined with \`source.url\` are supported (referencing a TileJSON), but this style.json has a source '${sourceId}' that does not have a \`url\` property`
         )
       }
-      if (isMapboxURL(source.url) && !accessToken) {
+
+      const isMapboxSource = isMapboxURL(source.url)
+
+      if (isMapboxSource && !accessToken) {
         throw new MBAccessTokenRequiredError()
       }
 
-      const upstreamUrl = normalizeSourceURL(source.url, accessToken)
+      const normalizedUpstreamSourceUrl = normalizeSourceURL(
+        source.url,
+        accessToken
+      )
 
-      const tilejson = await got(upstreamUrl).json()
+      const tilesetResponse = await upstreamRequestsManager.getUpstream({
+        url: normalizedUpstreamSourceUrl,
+        responseType: 'json',
+      })
 
-      if (!validateTileJSON(tilejson)) {
+      if (!validateTileJSON(tilesetResponse.data)) {
         // TODO: Write these errors to UnsupportedSourceError.message
 
         throw new UnsupportedSourceError(
@@ -200,10 +214,18 @@ function createStylesApi({
       // one offline copy of sources that are referenced from multiple styles,
       // e.g. lots of styles created on Mapbox will use the
       // mapbox.mapbox-streets-v7 source
-      const tilesetId = getTilesetId(tilejson)
+      const tilesetId = getTilesetId(tilesetResponse.data)
 
       if (!tilesetExists(tilesetId)) {
-        api.createTileset(tilejson, baseApiUrl)
+        api.createTileset(tilesetResponse.data, baseApiUrl, {
+          etag: tilesetResponse.etag,
+          upstreamUrl: isMapboxSource
+            ? source.url
+            : removeSearchParams(normalizedUpstreamSourceUrl, [
+                'access_token',
+                'secure',
+              ]),
+        })
       } else {
         // TODO: Should we update an existing tileset here?
         // api.putTileset(tilesetId, tilejson)

--- a/src/api/styles.ts
+++ b/src/api/styles.ts
@@ -180,9 +180,7 @@ function createStylesApi({
         )
       }
 
-      const isMapboxSource = isMapboxURL(source.url)
-
-      if (isMapboxSource && !accessToken) {
+      if (isMapboxURL(source.url) && !accessToken) {
         throw new MBAccessTokenRequiredError()
       }
 
@@ -213,6 +211,9 @@ function createStylesApi({
       if (!tilesetExists(tilesetId)) {
         api.createTileset(tilesetResponse.data, baseApiUrl, {
           etag: tilesetResponse.etag,
+          // Using the normalized url here means that the querystrings
+          // that may contain platform-specific parameters (e.g. access token)
+          // will be persisted in the db, allowing them to be reused by other styles.
           upstreamUrl: normalizedUpstreamSourceUrl,
         })
       } else {

--- a/src/api/styles.ts
+++ b/src/api/styles.ts
@@ -9,13 +9,7 @@ import {
   uncompositeStyle,
 } from '../lib/stylejson'
 import { TileJSON, validateTileJSON } from '../lib/tilejson'
-import {
-  encodeBase32,
-  generateId,
-  getTilesetId,
-  hash,
-  removeSearchParams,
-} from '../lib/utils'
+import { encodeBase32, generateId, getTilesetId, hash } from '../lib/utils'
 import { Api, Context, IdResource } from '.'
 import {
   AlreadyExistsError,
@@ -219,12 +213,7 @@ function createStylesApi({
       if (!tilesetExists(tilesetId)) {
         api.createTileset(tilesetResponse.data, baseApiUrl, {
           etag: tilesetResponse.etag,
-          upstreamUrl: isMapboxSource
-            ? source.url
-            : removeSearchParams(normalizedUpstreamSourceUrl, [
-                'access_token',
-                'secure',
-              ]),
+          upstreamUrl: normalizedUpstreamSourceUrl,
         })
       } else {
         // TODO: Should we update an existing tileset here?

--- a/src/api/tiles.ts
+++ b/src/api/tiles.ts
@@ -170,18 +170,6 @@ function createTilesApi({
           'INSERT INTO TileData (tileHash, tilesetId, data) VALUES (:tileHash, :tilesetId, :data)'
         ).run({ tileHash, tilesetId, data })
 
-        // TODO: Is this still necessary?
-        db.prepare<{
-          etag?: string
-          tilesetId: string
-          upstreamUrl?: string
-        }>(
-          'UPDATE Tileset SET (upstreamUrl) = (:upstreamUrl) WHERE id = :tilesetId'
-        ).run({
-          tilesetId,
-          upstreamUrl: upstreamTileUrl,
-        })
-
         db.prepare<{
           etag?: string
           quadKey: string

--- a/src/api/tilesets.ts
+++ b/src/api/tilesets.ts
@@ -20,8 +20,8 @@ export interface TilesetsApi {
   createTileset(
     tileset: TileJSON,
     baseApiUrl: string,
-    // `upstreamUrl` should be the canonicalized url if possible
-    // e.g. for a mapbox url, it should be "mapbox://..."
+    // `upstreamUrl` should be an http-based url
+    // e.g. for a mapbox url, it should be "https://api.mapbox.com/..."
     options?: { etag?: string; upstreamUrl?: string }
   ): TileJSON & IdResource
   getTileset(

--- a/src/api/tilesets.ts
+++ b/src/api/tilesets.ts
@@ -1,4 +1,3 @@
-import { FastifyInstance } from 'fastify'
 import mem from 'mem'
 import QuickLRU from 'quick-lru'
 
@@ -12,12 +11,24 @@ import {
   ParseError,
   UpstreamJsonValidationError,
 } from './errors'
+import { normalizeSourceURL } from '../lib/mapbox_urls'
+import { UpstreamResponse } from '../lib/upstream_requests_manager'
 
 function noop() {}
 
 export interface TilesetsApi {
-  createTileset(tileset: TileJSON, baseApiUrl: string): TileJSON & IdResource
-  getTileset(id: string, baseApiUrl: string): TileJSON & IdResource
+  createTileset(
+    tileset: TileJSON,
+    baseApiUrl: string,
+    // `upstreamUrl` should be the canonicalized url if possible
+    // e.g. for a mapbox url, it should be "mapbox://..."
+    options?: { etag?: string; upstreamUrl?: string }
+  ): TileJSON & IdResource
+  getTileset(
+    id: string,
+    baseApiUrl: string,
+    options?: { accessToken?: string }
+  ): TileJSON & IdResource
   getTilesetInfo(id: string): {
     tilejson: TileJSON
     upstreamTileUrls: TileJSON['tiles'] | undefined
@@ -26,7 +37,8 @@ export interface TilesetsApi {
   putTileset(
     id: string,
     tileset: TileJSON,
-    baseApiUrl: string
+    baseApiUrl: string,
+    options?: { etag?: string | null }
   ): TileJSON & IdResource
 }
 
@@ -74,8 +86,25 @@ function createTilesetsApi({ context }: { context: Context }): TilesetsApi {
     cache: new QuickLRU({ maxSize: 10 }),
   })
 
+  async function fetchUpstreamTilejson(
+    url: string,
+    etag?: string
+  ): Promise<{ tilejson: TileJSON; etag?: string }> {
+    const response = await upstreamRequestsManager.getUpstream({
+      url,
+      etag,
+      responseType: 'json',
+    })
+
+    if (!validateTileJSON(response.data)) {
+      throw new UpstreamJsonValidationError(url, validateTileJSON.errors)
+    }
+
+    return { tilejson: response.data, etag: response.etag }
+  }
+
   const tilesetsApi: TilesetsApi = {
-    createTileset(tilejson, baseApiUrl: string) {
+    createTileset(tilejson, baseApiUrl, { etag, upstreamUrl } = {}) {
       const tilesetId = getTilesetId(tilejson)
 
       if (tilesetExists(tilesetId)) {
@@ -92,14 +121,18 @@ function createTilesetsApi({ context }: { context: Context }): TilesetsApi {
         format: TileJSON['format']
         tilejson: string
         upstreamTileUrls?: string
+        upstreamUrl?: string
+        etag?: string
       }>(
-        'INSERT INTO Tileset (id, tilejson, format, upstreamTileUrls) ' +
-          'VALUES (:id, :tilejson, :format, :upstreamTileUrls)'
+        'INSERT INTO Tileset (id, tilejson, format, upstreamTileUrls, upstreamUrl, etag) ' +
+          'VALUES (:id, :tilejson, :format, :upstreamTileUrls, :upstreamUrl, :etag)'
       ).run({
         id: tilesetId,
         format: tilejson.format,
         tilejson: JSON.stringify(tilejson),
         upstreamTileUrls,
+        upstreamUrl,
+        etag,
       })
 
       return {
@@ -108,7 +141,7 @@ function createTilesetsApi({ context }: { context: Context }): TilesetsApi {
         tiles: [getTileUrl(baseApiUrl, tilesetId)],
       }
     },
-    getTileset(id, baseApiUrl) {
+    getTileset(id, baseApiUrl, { accessToken } = {}) {
       const row:
         | { tilejson: string; etag?: string; upstreamUrl?: string }
         | undefined = db
@@ -127,23 +160,18 @@ function createTilesetsApi({ context }: { context: Context }): TilesetsApi {
         throw new ParseError(err)
       }
 
-      async function fetchOnlineResource(url: string, etag?: string) {
-        const { data } = await upstreamRequestsManager.getUpstream({
-          url,
-          etag,
-          responseType: 'json',
-        })
-
-        if (!validateTileJSON(data)) {
-          // TODO: Do we want to throw here?
-          throw new UpstreamJsonValidationError(url, validateTileJSON.errors)
-        }
-
-        if (data) tilesetsApi.putTileset(id, data, baseApiUrl)
-      }
-
       if (row.upstreamUrl) {
-        fetchOnlineResource(row.upstreamUrl, row.etag).catch(noop)
+        const normalizedUpstreamUrl = normalizeSourceURL(
+          row.upstreamUrl,
+          accessToken
+        )
+
+        fetchUpstreamTilejson(normalizedUpstreamUrl, row.etag)
+          .then(({ tilejson, etag }) => {
+            tilesetsApi.putTileset(id, tilejson, baseApiUrl, { etag })
+          })
+          // TODO: Log error
+          .catch(noop)
       }
 
       return { ...tilejson, tiles: [getTileUrl(baseApiUrl, id)], id }
@@ -170,7 +198,7 @@ function createTilesetsApi({ context }: { context: Context }): TilesetsApi {
 
       return tilesets
     },
-    putTileset(id, tilejson, baseApiUrl) {
+    putTileset(id, tilejson, baseApiUrl, { etag } = {}) {
       if (id !== tilejson.id) {
         throw new MismatchedIdError(id, tilejson.id)
       }
@@ -199,6 +227,13 @@ function createTilesetsApi({ context }: { context: Context }): TilesetsApi {
             ? undefined
             : JSON.stringify(tilejson.tiles),
       })
+
+      // We only update the etag if one is expclcitly passed as a string or null value
+      if (etag !== undefined) {
+        db.prepare<{ id: string; etag: string | null }>(
+          'UPDATE Tileset SET etag = :etag WHERE id = :id'
+        ).run({ id, etag })
+      }
 
       mem.clear(memoizedGetTilesetInfo)
 

--- a/src/api/tilesets.ts
+++ b/src/api/tilesets.ts
@@ -228,7 +228,7 @@ function createTilesetsApi({ context }: { context: Context }): TilesetsApi {
             : JSON.stringify(tilejson.tiles),
       })
 
-      // We only update the etag if one is expclcitly passed as a string or null value
+      // We only update the etag if one is explicitly passed as a string or null value
       if (etag !== undefined) {
         db.prepare<{ id: string; etag: string | null }>(
           'UPDATE Tileset SET etag = :etag WHERE id = :id'

--- a/src/lib/stylejson.ts
+++ b/src/lib/stylejson.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/ban-types */
-import { URL } from 'url'
 // @ts-ignore
 import { validate as validateStyleJSON } from '@maplibre/maplibre-gl-style-spec'
 
@@ -8,15 +7,13 @@ import {
   StyleSpecification as StyleJSON,
 } from './style-spec'
 import { TileJSON } from './tilejson'
-import { encodeBase32, hash } from './utils'
+import { encodeBase32, hash, removeSearchParams } from './utils'
 
 // If the style has an `upstreamUrl` property, indicating where it was
 // downloaded from, then use that as the id (this way two clients that
 // download the same style do not result in duplicates)s
 function createIdFromStyleUrl(url: string) {
-  const u = new URL(url)
-  u.searchParams.delete('access_token')
-  return encodeBase32(hash(u.toString()))
+  return encodeBase32(hash(removeSearchParams(url, ['access_token'])))
 }
 
 /**

--- a/src/lib/stylejson.ts
+++ b/src/lib/stylejson.ts
@@ -11,7 +11,7 @@ import { encodeBase32, hash, removeSearchParams } from './utils'
 
 // If the style has an `upstreamUrl` property, indicating where it was
 // downloaded from, then use that as the id (this way two clients that
-// download the same style do not result in duplicates)s
+// download the same style do not result in duplicates)
 function createIdFromStyleUrl(url: string) {
   return encodeBase32(hash(removeSearchParams(url, ['access_token'])))
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,3 +1,4 @@
+import { URL } from 'url'
 import { createHash, randomBytes } from 'crypto'
 import base32 from 'base32.js'
 
@@ -51,4 +52,13 @@ export function isRejectedPromiseResult(
 export function getBaseApiUrl(request: FastifyRequest) {
   const { hostname, protocol } = request
   return `${protocol}://${hostname}`
+}
+
+export function removeSearchParams(
+  url: string,
+  paramsToRemove: string[]
+): string {
+  const u = new URL(url)
+  paramsToRemove.forEach((s) => u.searchParams.delete(s))
+  return u.toString()
 }

--- a/src/routes/tilesets.ts
+++ b/src/routes/tilesets.ts
@@ -7,6 +7,10 @@ const GetTilesetParamsSchema = T.Object({
   tilesetId: T.String(),
 })
 
+const GetTilesetQuerystringSchema = T.Object({
+  access_token: T.Optional(T.String()),
+})
+
 const GetTileParamsSchema = T.Object({
   tilesetId: T.String(),
   zoom: T.Number(),
@@ -42,24 +46,30 @@ const tilesets: FastifyPluginAsync = async function (fastify) {
     }
   )
 
-  fastify.get<{ Params: Static<typeof GetTilesetParamsSchema> }>(
+  fastify.get<{
+    Params: Static<typeof GetTilesetParamsSchema>
+    Querystring: Static<typeof GetTilesetQuerystringSchema>
+  }>(
     '/:tilesetId',
     {
       schema: {
-        params: GetTilesetParamsSchema,
         response: {
           200: TileJSONSchema,
         },
+        params: GetTilesetParamsSchema,
+        querystring: GetTilesetQuerystringSchema,
       },
     },
     async function (request) {
       return this.api.getTileset(
         request.params.tilesetId,
-        getBaseApiUrl(request)
+        getBaseApiUrl(request),
+        { accessToken: request.query.access_token }
       )
     }
   )
 
+  // TODO: Update body to include an optional `upstreamUrl` field so that we can fetch from upstream?
   fastify.post<{ Body: TileJSON }>(
     '/',
     {

--- a/src/routes/tilesets.ts
+++ b/src/routes/tilesets.ts
@@ -7,6 +7,9 @@ const GetTilesetParamsSchema = T.Object({
   tilesetId: T.String(),
 })
 
+// Clients like Mapbox will pass the access token in the querystring
+// but at the moment, we do not use it for anything since the persisted
+// upstream url will already have it included if required
 const GetTilesetQuerystringSchema = T.Object({
   access_token: T.Optional(T.String()),
 })
@@ -63,8 +66,7 @@ const tilesets: FastifyPluginAsync = async function (fastify) {
     async function (request) {
       return this.api.getTileset(
         request.params.tilesetId,
-        getBaseApiUrl(request),
-        { accessToken: request.query.access_token }
+        getBaseApiUrl(request)
       )
     }
   )

--- a/test/e2e/styles.test.js
+++ b/test/e2e/styles.test.js
@@ -243,6 +243,9 @@ test('GET /styles/:styleId when style exists returns style with sources pointing
       const responseTilesetGet = await server.inject({
         method: 'GET',
         url: source.url,
+        query: {
+          access_token: DUMMY_MB_ACCESS_TOKEN,
+        },
       })
 
       t.equal(responseTilesetGet.statusCode, 200)
@@ -460,6 +463,9 @@ test('DELETE /styles/:styleId deletes tilesets that are only referenced by the d
   const getTilesetBeforeResponse = await server.inject({
     method: 'GET',
     url: tilesetPathname,
+    query: {
+      access_token: DUMMY_MB_ACCESS_TOKEN,
+    },
   })
 
   t.equal(
@@ -604,10 +610,17 @@ test('DELETE /styles/:styleId does not delete referenced tilesets that are also 
   const tilesetBPathname = new URL(styleAB.sources.B.url).pathname
   const tilesetCPathname = new URL(styleBC.sources.C.url).pathname
 
-  const getTilesetAResponse = await server.inject({
-    method: 'GET',
-    url: tilesetAPathname,
-  })
+  async function getTileset(url) {
+    return server.inject({
+      method: 'GET',
+      url,
+      query: {
+        access_token: DUMMY_MB_ACCESS_TOKEN,
+      },
+    })
+  }
+
+  const getTilesetAResponse = await getTileset(tilesetAPathname)
 
   t.equal(
     getTilesetAResponse.statusCode,
@@ -615,10 +628,7 @@ test('DELETE /styles/:styleId does not delete referenced tilesets that are also 
     'tileset A no longer exists after style AB deletion'
   )
 
-  const getTilesetBResponse = await server.inject({
-    method: 'GET',
-    url: tilesetBPathname,
-  })
+  const getTilesetBResponse = await getTileset(tilesetBPathname)
 
   t.equal(
     getTilesetBResponse.statusCode,
@@ -626,10 +636,7 @@ test('DELETE /styles/:styleId does not delete referenced tilesets that are also 
     'tileset B still exists after style AB deletion'
   )
 
-  const getTilesetCResponse = await server.inject({
-    method: 'GET',
-    url: tilesetCPathname,
-  })
+  const getTilesetCResponse = await getTileset(tilesetCPathname)
 
   t.equal(
     getTilesetCResponse.statusCode,

--- a/test/e2e/styles.test.js
+++ b/test/e2e/styles.test.js
@@ -243,9 +243,7 @@ test('GET /styles/:styleId when style exists returns style with sources pointing
       const responseTilesetGet = await server.inject({
         method: 'GET',
         url: source.url,
-        query: {
-          access_token: DUMMY_MB_ACCESS_TOKEN,
-        },
+        query: { access_token: DUMMY_MB_ACCESS_TOKEN },
       })
 
       t.equal(responseTilesetGet.statusCode, 200)
@@ -463,9 +461,7 @@ test('DELETE /styles/:styleId deletes tilesets that are only referenced by the d
   const getTilesetBeforeResponse = await server.inject({
     method: 'GET',
     url: tilesetPathname,
-    query: {
-      access_token: DUMMY_MB_ACCESS_TOKEN,
-    },
+    query: { access_token: DUMMY_MB_ACCESS_TOKEN },
   })
 
   t.equal(
@@ -614,9 +610,7 @@ test('DELETE /styles/:styleId does not delete referenced tilesets that are also 
     return server.inject({
       method: 'GET',
       url,
-      query: {
-        access_token: DUMMY_MB_ACCESS_TOKEN,
-      },
+      query: { access_token: DUMMY_MB_ACCESS_TOKEN },
     })
   }
 


### PR DESCRIPTION
Fixes #63 

When creating a style, we save the normalized upstream url (i.e. http-based url) for each source we create for it, which allows us to make proper/valid upstream requests when needed.