### PR TITLE
fix: improve handling of import progress endpoint when import error occurs

### DIFF
--- a/API.md
+++ b/API.md
@@ -11,6 +11,7 @@ Params of interest are prefixed by a colon (`:`) in the listed endpoint.
 - [Fonts](#fonts)
 - [Tilesets](#tilesets)
 - [Tiles](#tiles)
+- [Imports](#imports)
 
 ---
 
@@ -201,13 +202,14 @@ Messages that are received will have a `data` field with the following structure
 - `type: string`: Type indicating the type of progress message. Can be one of the following values:
   - `"progress"`: Import is still in progress
   - `"complete"`: Import is complete
+  - `"error"`: Error occurred during import
 - `importId: string`: ID for import
 - `soFar: number`: Number of assets successfully imported so far
 - `total: number`: Total number of assets to be imported
 
 If a requested import is already completed or has errored, responds with `204 No Content`, which should prevent the event source from attempting to reconnect. Generally, the client should explicitly close the event source when:
 
-1. Receiving a message and the deserialized `type` value in the event data is either `"complete"` or `"progress"`.
+1. Receiving a message and the deserialized `type` value in the event data is either `"complete"` or `"error"`.
 2. Receiving an error
 
 ```js
@@ -218,7 +220,7 @@ const evtSource = new EventSource(
 evtSource.onmessage = (event) => {
   const message = JSON.parse(event.data)
 
-  if (message.type === 'complete') {
+  if (message.type === 'complete' || message.type === 'error') {
     evtSource.close()
     return
   }

--- a/src/api/imports.ts
+++ b/src/api/imports.ts
@@ -132,7 +132,9 @@ function createImportsApi({
             // If a sqlite error is raised and the import has not started
             // we assume that there is an issue reading the mbtiles file provided
             const isMbTilesIssue =
-              err?.code.startsWith('SQLITE') && !importStarted
+              typeof err?.code === 'string' &&
+              err.code.startsWith('SQLITE') &&
+              !importStarted
 
             // FYI this will be called when piscina.destroy() in the onClose hook
             rej(isMbTilesIssue ? new MBTilesCannotReadError(err.code) : err)

--- a/src/lib/imports.ts
+++ b/src/lib/imports.ts
@@ -3,7 +3,15 @@ import { Static, Type as T } from '@sinclair/typebox'
 
 import { NullableSchema } from './utils'
 
-const ImportErrorSchema = T.Union([T.Literal('TIMEOUT'), T.Literal('UNKNOWN')])
+export const IMPORT_ERRORS = {
+  TIMEOUT: 'TIMEOUT',
+  UNKNOWN: 'UNKNOWN',
+} as const
+
+const ImportErrorSchema = T.Union([
+  T.Literal(IMPORT_ERRORS.TIMEOUT),
+  T.Literal(IMPORT_ERRORS.UNKNOWN),
+])
 export type ImportError = Static<typeof ImportErrorSchema>
 
 const ImportState = T.Union([

--- a/src/lib/mbtiles_import_worker.d.ts
+++ b/src/lib/mbtiles_import_worker.d.ts
@@ -36,6 +36,10 @@ export interface Queries {
     importedResources: number
     importedBytes: number
   }>
+  setImportError: Statement<{
+    id: string
+    error: string
+  }>
   completeImport: Statement<{
     id: string
     importedResources: number
@@ -67,5 +71,12 @@ export type MessageComplete = {
   total: number
 }
 
+export type MessageError = {
+  type: 'error'
+  importId: string
+  soFar: number
+  total: number
+}
+
 // Message types received by the port (main thread)
-export type PortMessage = MessageProgress | MessageComplete
+export type PortMessage = MessageProgress | MessageComplete | MessageError

--- a/test/e2e/imports.test.js
+++ b/test/e2e/imports.test.js
@@ -230,8 +230,7 @@ test('GET /imports/progress/:importId - EventSource forced to close after single
   })
 })
 
-// Failing test
-test.skip('GET /imports/:importId after deferred import error shows error state', async (t) => {
+test('GET /imports/:importId after deferred import error shows error state', async (t) => {
   const server = createServer(t)
   // This mbtiles file has one of the tile_data fields set to null. This causes
   // the import to initially report progress, but fail when it reaches the null


### PR DESCRIPTION
Notes:

- Noticed a failing import test that was skipped and decided to address it. If the read row has invalid data, we update the import record to reflect the error state and send an `error` message to the main thread.
- Question: currently we set the import record's `error` field to `UNKNOWN` in this case, although maybe it would be more useful to have a slightly more descriptive error that reflects the unexpected bad data