### PR TITLE
fix: avoid redundant attempt at deleting style when import worker timeout occurs

### DIFF
--- a/src/api/imports.ts
+++ b/src/api/imports.ts
@@ -171,8 +171,6 @@ function createImportsApi({
               db.prepare(
                 "UPDATE Import SET state = 'error', finished = CURRENT_TIMESTAMP, error = 'TIMEOUT' WHERE id = ?"
               ).run(importId)
-            } else {
-              api.deleteStyle(styleId, baseApiUrl)
             }
           } catch (err) {
             // TODO: This could potentially throw when the db is closed already. Need to properly handle/report

--- a/test/e2e/imports.test.js
+++ b/test/e2e/imports.test.js
@@ -230,6 +230,7 @@ test('GET /imports/progress/:importId - EventSource forced to close after single
   })
 })
 
+// TODO: Potentially flaky test
 test('GET /imports/:importId after deferred import error shows error state', async (t) => {
   const server = createServer(t)
   // This mbtiles file has one of the tile_data fields set to null. This causes

--- a/test/e2e/tilesets-import.test.js
+++ b/test/e2e/tilesets-import.test.js
@@ -356,3 +356,5 @@ test('POST /tilesets/import fails when providing invalid mbtiles, no tilesets or
   t.equal(stylesRes.statusCode, 200)
   t.same(stylesRes.json(), [], 'no styles created')
 })
+
+// TODO: Add test for worker timeout


### PR DESCRIPTION
Noticed while attempting to integrate into mapeo mobile, but when our message timeout expires, it cancels the Piscina task and attempts to delete the style if the worker never sent its first message to main thread. However, upon cancellation, the Piscina task also attempts to delete the style. This causes an undesirable unhandled error.

Now we defer the style deletion to the cancelled Piscina task and remove that logic from the message timeout handler (or maybe it should it be the other way around?). Ideally a test would be added simulating the worker timeout, but not entirely sure how to create that situation via a test, so left a comment for now.