### PR TITLE
feat!: accept database instance instead of path when creating server 

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,42 +4,47 @@
 
 An in-progress offline map style and tile server for Mapeo.
 
-`npm install @mapeo/map-server`
+`npm install @mapeo/map-server better-sqlite3`
 
-*⚠️ This is alpha software. No guarantees can be made about the stability of the API at the moment, so proceed with caution. 😄*
+_⚠️ This is alpha software. No guarantees can be made about the stability of the API at the moment, so proceed with caution. 😄_
 
 ## Features
 
-- [X] Manages tiles and tilesets (TileJSON)
+- [x] Manages tiles and tilesets (TileJSON)
 
-- [X] Manages Mapbox map styles
+- [x] Manages Mapbox map styles
 
-- [X] Supports importing MBTile files as tilesets
-  - [X] Supports getting import progress
+- [x] Supports importing MBTile files as tilesets
+
+  - [x] Supports getting import progress
 
 - [ ] Provides info related to downloads and storage
-
 
 ## Usage
 
 The default export is a factory function for creating a map server instance, which is built on top of [Fastify](https://www.fastify.io/). Basic usage is as follows:
 
 ```js
+// better-sqlite3 is a peer dependency and must be installed manually.
+const Database = require('better-sqlite3')
 // If you're using TypeScript, you may want to use one of the following import syntaxes to get type definitions:
 // - `require('@mapeo/map-server').default`
 // - `import createMapServer from '@mapeo/map-server'
-const createMapServer = require("@mapeo/map-server");
+const createMapServer = require('@mapeo/map-server')
 
 // Create the server instance
-const mapServer = createMapServer({ logger: true }, { dbPath: "./example.db" });
+const mapServer = createMapServer(
+  { logger: true },
+  { data: new Database('./example.db') }
+)
 
 // Run the server!
 mapServer.listen(3000, function (err) {
   if (err) {
-    mapServer.log.error(err);
-    process.exit(1);
+    mapServer.log.error(err)
+    process.exit(1)
   }
-});
+})
 ```
 
 ### `createServer(fastifyOpts, mapServerOpts): FastifyInstance`
@@ -48,7 +53,7 @@ Creates the map server instance
 
 - `fastifyOpts (optional)`: Options object to customize the Fastify instance. Refer to the [official Fastify documentation](https://www.fastify.io/docs/latest/Reference/Server/) for more details.
 - `mapServerOpts (required)`: Options object to customize the map server instance. Options include:
-  - `dbPath: string (required)`: File path that points to the SQLite database to use. If the file does not exist, it will be created.
+  - `database: BetterSqlite3.Database (required)`: [BetterSqlite3](https://github.com/WiseLibs/better-sqlite3) database instance representing the SQLite database to use.
 
 ## API Documentation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1956,6 +1956,7 @@
       "version": "7.6.2",
       "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-7.6.2.tgz",
       "integrity": "sha512-S5zIU1Hink2AH4xPsN0W43T1/AJ5jrPh7Oy07ocuW/AKYYY02GWzz9NH0nbSMn/gw6fDZ5jZ1QsHt1BXAwJ6Lg==",
+      "dev": true,
       "requires": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.0"
@@ -1971,6 +1972,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
       "requires": {
         "file-uri-to-path": "1.0.0"
       }
@@ -1979,6 +1981,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
       "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
       "requires": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
@@ -1989,6 +1992,7 @@
           "version": "3.6.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
           "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -2019,6 +2023,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.0.tgz",
       "integrity": "sha512-cd+5r1VLBwUqTrmnzW+D7ABkJUM6mr7uv1dv+6jRw4Rcl7tFIFHDqHPL98LhpGFn3dbAt3gtLxtrWp4m1kFrqg==",
+      "dev": true,
       "requires": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -2257,7 +2262,8 @@
     "chownr": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "dev": true
     },
     "ci-info": {
       "version": "2.0.0",
@@ -3832,7 +3838,8 @@
     "deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true
     },
     "deep-is": {
       "version": "0.1.4",
@@ -3927,7 +3934,8 @@
     "detect-libc": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
-      "integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w=="
+      "integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==",
+      "dev": true
     },
     "detect-newline": {
       "version": "3.1.0",
@@ -4546,7 +4554,8 @@
     "expand-template": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "dev": true
     },
     "extract-zip": {
       "version": "2.0.1",
@@ -4803,7 +4812,8 @@
     "file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true
     },
     "fill-range": {
       "version": "7.0.1",
@@ -4940,7 +4950,8 @@
     "fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true
     },
     "fs-extra": {
       "version": "7.0.1",
@@ -5170,7 +5181,8 @@
     "github-from-package": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "dev": true
     },
     "glob": {
       "version": "7.1.6",
@@ -5564,7 +5576,8 @@
     "ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true
     },
     "ignore": {
       "version": "5.1.9",
@@ -5611,7 +5624,8 @@
     "ini": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true
     },
     "internal-slot": {
       "version": "1.0.3",
@@ -6727,7 +6741,8 @@
     "mkdirp-classic": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "dev": true
     },
     "modify-values": {
       "version": "1.0.1",
@@ -6755,7 +6770,8 @@
     "napi-build-utils": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
-      "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg=="
+      "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==",
+      "dev": true
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -6810,9 +6826,10 @@
       }
     },
     "node-abi": {
-      "version": "3.28.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.28.0.tgz",
-      "integrity": "sha512-fRlDb4I0eLcQeUvGq7IY3xHrSb0c9ummdvDSYWfT9+LKP+3jCKw/tKoqaM7r1BAoiAC6GtwyjaGnOz6B3OtF+A==",
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.31.0.tgz",
+      "integrity": "sha512-eSKV6s+APenqVh8ubJyiu/YhZgxQpGP66ntzUb3lY1xB9ukSRaGnx0AIxI+IM+1+IVYC1oWobgG5L3Lt9ARykQ==",
+      "dev": true,
       "requires": {
         "semver": "^7.3.5"
       },
@@ -6821,6 +6838,7 @@
           "version": "7.3.8",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
           "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -7316,6 +7334,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
       "integrity": "sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==",
+      "dev": true,
       "requires": {
         "detect-libc": "^2.0.0",
         "expand-template": "^2.0.3",
@@ -7768,6 +7787,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
       "requires": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -8169,12 +8189,14 @@
     "simple-concat": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "dev": true
     },
     "simple-get": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
       "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "dev": true,
       "requires": {
         "decompress-response": "^6.0.0",
         "once": "^1.3.1",
@@ -8543,7 +8565,8 @@
     "strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true
     },
     "stylis": {
       "version": "4.1.1",
@@ -8771,6 +8794,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
       "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+      "dev": true,
       "requires": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",
@@ -8782,6 +8806,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
       "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
       "requires": {
         "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
@@ -8794,6 +8819,7 @@
           "version": "3.6.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
           "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -9115,6 +9141,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "dev": true,
       "requires": {
         "safe-buffer": "^5.0.1"
       }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "@types/readable-stream": "^2.3.15",
     "ajv": "^8.11.0",
     "base32.js": "^0.1.0",
-    "better-sqlite3": "^7.6.2",
     "fastify": "^3.29.0",
     "fastify-oas": "^3.0.8",
     "fastify-plugin": "^3.0.1",
@@ -57,6 +56,9 @@
     "quick-lru": "^5.1.1",
     "readable-stream": "^3.6.0",
     "uuid": "^8.3.2"
+  },
+  "peerDependencies": {
+    "better-sqlite3": ">=7.6.0"
   },
   "devDependencies": {
     "@fastify/etag": "^3.0.0",
@@ -75,6 +77,7 @@
     "@types/uuid": "^8.3.4",
     "@typescript-eslint/eslint-plugin": "^5.43.0",
     "@typescript-eslint/parser": "^5.43.0",
+    "better-sqlite3": "^7.6.2",
     "c8": "^7.12.0",
     "eslint": "^8.2.0",
     "eslint-config-prettier": "^8.3.0",

--- a/server.ts
+++ b/server.ts
@@ -1,9 +1,10 @@
 import 'make-promises-safe'
+import Database from 'better-sqlite3'
 
 import createMapServer, { MapServerOptions } from './src/app'
 
 const mapServerOpts: MapServerOptions = {
-  dbPath: './example.db',
+  database: new Database('./example.db'),
 }
 
 // Require the framework and instantiate it

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,4 +1,4 @@
-import Db, { Database } from 'better-sqlite3'
+import { Database } from 'better-sqlite3'
 import { FastifyPluginAsync } from 'fastify'
 import fp from 'fastify-plugin'
 import path from 'path'
@@ -120,7 +120,7 @@ const ApiPlugin: FastifyPluginAsync<MapServerOptions> = async (
   fastify,
   { database }
 ) => {
-  if (database == null || !(database instanceof Db))
+  if (database == null)
     throw new Error(
       `Instance of BetterSqlite3.Database must be specified for 'database' option (https://github.com/WiseLibs/better-sqlite3/blob/master/docs/api.md#class-database)`
     )

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,4 +1,5 @@
-import { Database } from 'better-sqlite3'
+// @ts-ignore
+import type { Database } from 'better-sqlite3'
 import { FastifyPluginAsync } from 'fastify'
 import fp from 'fastify-plugin'
 import path from 'path'

--- a/test/test-helpers/create-server.js
+++ b/test/test-helpers/create-server.js
@@ -1,6 +1,7 @@
 const tmp = require('tmp')
 const path = require('path')
 const fs = require('fs')
+const Db = require('better-sqlite3')
 
 const createMapServer = require('../..')
 
@@ -26,7 +27,7 @@ function createServer(t) {
 
   const server = createMapServer(
     { logger: false, forceCloseConnections: true },
-    { dbPath }
+    { database: new Db(dbPath) }
   )
 
   t.teardown(async () => {


### PR DESCRIPTION
Closes #92 

**This is a breaking change**, as it updates the function signature of the export `createServer` function to accept an instance of a BetterSqlite3 database instead of a file path string.

- Removes `better-sqlite3` from `depedencies` field
- Adds `better-sqlite3` to `peerDependencies` and `devDependencies` fields
- Updates `MapServerOptions` from `{ dbPath: string }` to `{ database: Database }`