### PR TITLE
chore: remove redundant SDF generation in CI

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -25,6 +25,4 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
       - run: npm ci
-      - name: Generate SDFs
-        run: node scripts/generate-sdf.js
       - run: npm test


### PR DESCRIPTION
`npm test` will generate SDFs, so we don't need to do it independently.