### PR TITLE
perf: speed up style deletion

### DIFF
--- a/prisma/migrations/20240207033957_init/migration.sql
+++ b/prisma/migrations/20240207033957_init/migration.sql
@@ -91,4 +91,7 @@ CREATE TABLE "Import" (
 );
 
 -- CreateIndex
+CREATE INDEX "Tile_tileHash_tilesetId_idx" ON "Tile"("tileHash", "tilesetId");
+
+-- CreateIndex
 CREATE UNIQUE INDEX "Import_areaId_key" ON "Import"("areaId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -32,6 +32,9 @@ model Tile {
   tilesetId String
 
   @@id([quadKey, tilesetId])
+
+  // Makes foreign key lookups much faster.
+  @@index([tileHash, tilesetId])
 }
 
 model Tileset {

--- a/test/e2e/styles.test.js
+++ b/test/e2e/styles.test.js
@@ -333,6 +333,10 @@ test('DELETE /styles/:styleId when style exists returns 204 status code and empt
   t.equal(responsePost.statusCode, 200)
   t.ok(mockedTilesetScope.isDone(), 'upstream request was made')
 
+  // Style deletion used to be very slow. This timeout ensures we don't have a regression.
+  // See <https://github.com/digidem/mapeo-map-server/pull/116>
+  t.timeoutAfter(15_000)
+
   const responseDelete = await server.inject({
     method: 'DELETE',
     url: `/styles/${id}`,


### PR DESCRIPTION
The [original issue][0] has useful background for this change:

> Calling api.deleteStyle can take a long time under the following conditions:
>
> * multiple relatively exclusive tilesets exist in the db
> * sufficient number of tile data (say at least ~100 MB)
>
> Replicate this by doing two mbtiles imports, waiting for them to complete, and deleting either one of the styles associated with it.  The example I tried imported a small map (~10 MB) and the Terrastories default offline map (~150 MB), and attempting to delete either map style.
>
> Bottleneck seems to be this query (takes about 16 seconds on my machine):
>
> ```
> DELETE FROM TileData WHERE tilesetId IN (${tilesetsSqlList})`
> ```

Why was this query so slow?

To find out, I compiled[^A] SQLite with [profiling][1] and ran the deletion queries manually. When I ran the bad query, I saw this (formatted lightly):

```
QUERY PLAN (cycles=58188228963 [100%])
|--SCAN TileData (cycles=166585395 [0%] loops=1 rows=31647)
`--SCAN Tile     (cycles=43414842720 [75%] loops=29443 rows=160788223)
```

This seems to be slow because it's doing *29 thousand full scans* of the `Tile` table. Adding this index turns those scans into searches (again, formatted slightly):

```
QUERY PLAN (cycles=519584520 [100%])
|--SCAN TileData (cycles=134107686 [26%] loops=1 rows=31647)
`--SEARCH Tile USING COVERING INDEX Tile_tileHash_tilesetId_idx (tileHash=? AND tilesetId=?) (cycles=62592162 [12%] loops=29443 rows=0)
```

After this change, the bad query takes about 300 milliseconds on my machine. Still a bit high, but more acceptable.

Fixes #89.

[^A]: To do this, I downloaded the basic SQLite amalgamation from <https://sqlite.org/download.html>. I edited `sqlite3.c` to add [the options that better-sqlite3 adds][2], then compiled the shell with `gcc -DSQLITE_THREADSAFE=0 -DSQLITE_OMIT_PROGRESS_CALLBACK -DSQLITE_ENABLE_STMT_SCANSTATUS=1 shell.c sqlite3.c -ldl -lm -o sqlite3`. (I disabled thread safety because it's not necessary for the CLI, the progress callback because it gave me a compile error, and `STMT_SCANSTATUS` so I could do my profiling.)

[0]: https://github.com/digidem/mapeo-map-server/issues/89
[1]: https://sqlite.org/profile.html
[2]: https://github.com/WiseLibs/better-sqlite3/blob/543c0f5c706088f82a4d5b5ac5847de6cf8a43fc/docs/compilation.md#bundled-configuration
