### PR TITLE
chore: clean up SQL bindings when deleting styles

### DIFF
--- a/src/api/styles.ts
+++ b/src/api/styles.ts
@@ -339,16 +339,18 @@ function createStylesApi({
         .pluck(true)
         .all({ styleId: id })
 
-      const tilesetsSqlList = tilesetsToDelete.map((id) => `'${id}'`).join(',')
+      const tilesetsBindParameters = tilesetsToDelete.map(() => `?`).join(',')
 
       db.transaction(() => {
         db.prepare(
-          `DELETE FROM Tile WHERE tilesetId IN (${tilesetsSqlList})`
-        ).run()
-        db.prepare(`DELETE FROM Tileset WHERE id IN (${tilesetsSqlList})`).run()
+          `DELETE FROM Tile WHERE tilesetId IN (${tilesetsBindParameters})`
+        ).run(tilesetsToDelete)
         db.prepare(
-          `DELETE FROM TileData WHERE tilesetId IN (${tilesetsSqlList})`
-        ).run()
+          `DELETE FROM Tileset WHERE id IN (${tilesetsBindParameters})`
+        ).run(tilesetsToDelete)
+        db.prepare(
+          `DELETE FROM TileData WHERE tilesetId IN (${tilesetsBindParameters})`
+        ).run(tilesetsToDelete)
         db.prepare(
           'DELETE FROM Import WHERE areaId IN (SELECT id FROM OfflineArea WHERE styleId = ?)'
         ).run(id)


### PR DESCRIPTION
Previously, we ran a query that was basically like this:

```javascript
db.prepare(
  `DELETE FROM my_table WHERE id IN (1, 2, 3)`
).run()
```

Now, we run the query like this:

```javascript
db.prepare(
  `DELETE FROM my_table WHERE id IN (?, ?, ?)`
).run([1, 2, 3])
```

Though I think it was never a problem in practice, this prevents SQL injection attacks if the IDs contained SQL somehow.