### PR TITLE
chore: use SELECT EXISTS where applicable

### DIFF
--- a/src/api/sprites.ts
+++ b/src/api/sprites.ts
@@ -49,15 +49,15 @@ function createSpritesApi({ context }: { context: Context }): SpritesApi {
     const query =
       pixelDensity === undefined
         ? db
-            .prepare('SELECT COUNT(*) AS count FROM Sprite WHERE id = ?')
+            .prepare('SELECT EXISTS (SELECT 1 FROM Sprite WHERE id = ?)')
             .bind(spriteId)
         : db
             .prepare<{ spriteId: string; pixelDensity: number }>(
-              'SELECT COUNT(*) AS count FROM Sprite WHERE id = :spriteId AND pixelDensity = :pixelDensity'
+              'SELECT EXISTS (SELECT 1 FROM Sprite WHERE id = :spriteId AND pixelDensity = :pixelDensity)'
             )
             .bind({ spriteId, pixelDensity })
 
-    return query.get().count > 0
+    return query.pluck().get() !== 0
   }
 
   return {

--- a/src/api/styles.ts
+++ b/src/api/styles.ts
@@ -95,8 +95,9 @@ function createStylesApi({
   function styleExists(styleId: string) {
     return (
       db
-        .prepare('SELECT COUNT(*) AS count FROM Style WHERE id = ?')
-        .get(styleId).count > 0
+        .prepare('SELECT EXISTS (SELECT 1 FROM Style WHERE id = ?)')
+        .pluck()
+        .get(styleId) !== 0
     )
   }
 
@@ -145,8 +146,9 @@ function createStylesApi({
   function tilesetExists(tilesetId: string) {
     return (
       db
-        .prepare('SELECT COUNT(*) AS count FROM Tileset WHERE id = ?')
-        .get(tilesetId).count > 0
+        .prepare('SELECT EXISTS (SELECT 1 FROM Tileset WHERE id = ?)')
+        .pluck()
+        .get(tilesetId) !== 0
     )
   }
 

--- a/src/api/tilesets.ts
+++ b/src/api/tilesets.ts
@@ -44,8 +44,9 @@ function createTilesetsApi({ context }: { context: Context }): TilesetsApi {
   function tilesetExists(tilesetId: string) {
     return (
       db
-        .prepare('SELECT COUNT(*) AS count FROM Tileset WHERE id = ?')
-        .get(tilesetId).count > 0
+        .prepare('SELECT EXISTS (SELECT 1 FROM Tileset WHERE id = ?)')
+        .pluck()
+        .get(tilesetId) !== 0
     )
   }
 

--- a/src/lib/migrations.ts
+++ b/src/lib/migrations.ts
@@ -28,9 +28,10 @@ export function migrate(db: Database, migrationsDirPath: string) {
   const migrationsTableExists =
     db
       .prepare(
-        "SELECT COUNT(name) as count FROM sqlite_master WHERE type = 'table' AND name = '_prisma_migrations'"
+        "SELECT EXISTS (SELECT 1 FROM sqlite_master WHERE type IS 'table' AND name IS '_prisma_migrations')"
       )
-      .get().count > 0
+      .pluck()
+      .get() !== 0
 
   if (!migrationsTableExists) {
     // Taken from `prisma-engines` with a slight alteration to how we store dates (we want more granular):

--- a/test/unit/migrations.test.js
+++ b/test/unit/migrations.test.js
@@ -145,9 +145,10 @@ test('Works when database schema is not initialized', (t) => {
     return (
       db
         .prepare(
-          "SELECT COUNT(name) as count FROM sqlite_master WHERE type = 'table' AND name = '_prisma_migrations'"
+          "SELECT EXISTS (SELECT 1 FROM sqlite_master WHERE type IS 'table' AND name IS '_prisma_migrations')"
         )
-        .get().count > 0
+        .pluck()
+        .get() !== 0
     )
   }
 


### PR DESCRIPTION
*This change is not urgent.*

Sometimes, you want to know whether at least one row matches a query. In my opinion, [SELECT EXISTS] is the best way to do this for two reasons:

1. It states intent more clearly than other methods.
2. It is faster than other methods.[^faster]

Currently, we use SELECT COUNT(*) and check if the count is > 0. This patch moves things to use SELECT EXISTS.

[^faster]: Intuitively, I expected SELECT EXISTS to be faster because you don't need the precise count—you just need to know whether a query returns any results at all. But how much faster? I wrote a simple [profiling script] to test this. On my machine, it was between ~1.5x faster when checking for the existence of a single row by primary key and ~1300x faster when a full table scan would have been required. In fairness, the performance difference was fairly small—only a few milliseconds different at most—in absolute terms.

[SELECT EXISTS]: https://www.sqlite.org/lang_expr.html#the_exists_operator
[profiling script]: https://gist.github.com/EvanHahn/f2ab85cc5fed0c26186adfb9bf0c51ed