### PR TITLE
chore: use upstream types for @mapbox/whoots-js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "@types/is-url": "^1.2.30",
         "@types/mapbox__point-geometry": "^0.1.2",
         "@types/mapbox__sphericalmercator": "^1.1.5",
+        "@types/mapbox__whoots-js": "^3.1.0",
         "@types/node": "^18.11.9",
         "@types/tape": "^4.13.4",
         "@types/tilebelt": "^1.0.3",
@@ -2774,6 +2775,12 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@types/mapbox__sphericalmercator/-/mapbox__sphericalmercator-1.2.0.tgz",
       "integrity": "sha512-cl3re1m12LzVj1oSDFoEZ6Bmf60Qdx5FQyuT70QIjNKFbNY6XOgwDHCd0rqtmxzJrfQjd9yOmtUVIp+803Uugg==",
+      "dev": true
+    },
+    "node_modules/@types/mapbox__whoots-js": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/mapbox__whoots-js/-/mapbox__whoots-js-3.1.0.tgz",
+      "integrity": "sha512-HsqX0yvy0C5byD+CZC1cS8W+ibjmU5fskUdWuVYGOLEFpcIy2AaOZE/RAIrkBcVU1jzkkE0RSKNV1cQr7ReOgA==",
       "dev": true
     },
     "node_modules/@types/minimist": {

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@types/is-url": "^1.2.30",
     "@types/mapbox__point-geometry": "^0.1.2",
     "@types/mapbox__sphericalmercator": "^1.1.5",
+    "@types/mapbox__whoots-js": "^3.1.0",
     "@types/node": "^18.11.9",
     "@types/tape": "^4.13.4",
     "@types/tilebelt": "^1.0.3",

--- a/types/@mapbox__whoots-js.d.ts
+++ b/types/@mapbox__whoots-js.d.ts
@@ -1,3 +1,0 @@
-declare module '@mapbox/whoots-js' {
-  export function getTileBBox(x: number, y: number, z: number): string
-}


### PR DESCRIPTION
[@types/mapbox__whoots-js was recently added][0] so we can use it and delete our own types.

[0]: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68550
