### PR TITLE
refactor!: move style list from HTTP API to JS API

### DIFF
--- a/API.md
+++ b/API.md
@@ -15,15 +15,6 @@ Params of interest are prefixed by a colon (`:`) in the listed endpoint.
 
 ## Styles
 
-### `GET /styles`
-
-Retrieve a list of information about all styles. Each item has the following fields:
-
-- `id: string`: ID of the style
-- `bytesStored: number`: The number of bytes that the style occupies. This currently only accounts for the tiles that are associated with the style. In the future, this should include other assets such as glyphs and sprites.
-- `name: string`: The name of the style.
-- `url: string`: The map server URL that points to the style resource.
-
 ### `GET /styles/:styleId`
 
 - Params

--- a/src/api/styles.ts
+++ b/src/api/styles.ts
@@ -22,6 +22,25 @@ interface SourceIdToTilesetId {
   [sourceId: keyof StyleJSON['sources']]: string
 }
 
+export type StyleResource = IdResource & {
+  /**
+   * The ID of the style.
+   */
+  id: string
+
+  /**
+   * The number of bytes that the style occupies.
+   *
+   * This currently only accounts for the tiles that are associated with the style. In the future, this should include other assets such as glyphs and sprites.
+   */
+  bytesStored: number
+
+  /**
+   * The name of the style. May be `null`.
+   */
+  name: null | string
+}
+
 export interface StylesApi {
   createStyle(
     style: StyleJSON,
@@ -39,13 +58,7 @@ export interface StylesApi {
   ): { style: StyleJSON } & IdResource
   deleteStyle(id: string, baseApiUrl: string): void
   getStyle(id: string, baseApiUrl: string): StyleJSON
-  listStyles(baseApiUrl: string): Array<
-    {
-      bytesStored: number
-      name: string | null
-      url: string
-    } & IdResource
-  >
+  listStyles(): Array<StyleResource>
   updateStyle(
     id: string,
     style: StyleJSON,
@@ -398,7 +411,7 @@ function createStylesApi({
         styleId: id,
       })
     },
-    listStyles(baseApiUrl) {
+    listStyles() {
       // `bytesStored` calculates the total bytes stored by tiles that the style references
       // Eventually we want to get storage taken up by other resources like sprites and glyphs
       return db
@@ -424,7 +437,6 @@ function createStylesApi({
           }) => ({
             ...row,
             bytesStored: row.bytesStored || 0,
-            url: getStyleUrl(baseApiUrl, row.id),
           })
         )
     },

--- a/src/map-server.ts
+++ b/src/map-server.ts
@@ -11,6 +11,7 @@ import { convertActiveToError as convertActiveImportsToErrorImports } from './li
 import { migrate } from './lib/migrations'
 import { UpstreamRequestsManager } from './lib/upstream_requests_manager'
 import type { IdResource } from './api/index'
+import type { StyleResource } from './api/styles'
 import type { ImportRecord } from './lib/imports'
 import type { PortMessage } from './lib/mbtiles_import_worker.d.ts'
 import type { TileJSON } from './lib/tilejson'
@@ -42,6 +43,13 @@ export default class MapServer {
     })
 
     this.fastifyInstance = createMapFastifyServer(this.#api, fastifyOpts)
+  }
+
+  /**
+   * Retrieve a list of all style records.
+   */
+  listStyles(): Array<StyleResource> {
+    return this.#api.listStyles()
   }
 
   /**

--- a/src/routes/styles.ts
+++ b/src/routes/styles.ts
@@ -50,17 +50,6 @@ function validateStyle(style: unknown): asserts style is StyleJSON {
 }
 
 const styles: FastifyPluginAsync = async function (fastify) {
-  fastify.get<{
-    Reply: {
-      bytesStored: number
-      id: string
-      name: string | null
-      url: string
-    }[]
-  }>('/', async function (request) {
-    return this.api.listStyles(getBaseApiUrl(request))
-  })
-
   fastify.post<{
     Body: { accessToken?: string } & (
       | { url: string }

--- a/test/e2e/tilesets-crud.test.js
+++ b/test/e2e/tilesets-crud.test.js
@@ -76,9 +76,10 @@ test('POST /tilesets when tileset does not exist creates a tileset and returns i
 })
 
 test('POST /tilesets creates a style for the raster tileset', async (t) => {
-  const server = createServer(t).fastifyInstance
+  const server = createServer(t)
+  const { fastifyInstance } = server
 
-  const responseTilesetsPost = await server.inject({
+  const responseTilesetsPost = await fastifyInstance.inject({
     method: 'POST',
     url: '/tilesets',
     payload: sampleTileJSON,
@@ -86,18 +87,12 @@ test('POST /tilesets creates a style for the raster tileset', async (t) => {
 
   const { id: tilesetId, name: expectedName } = responseTilesetsPost.json()
 
-  const responseStylesListGet = await server.inject({
-    method: 'GET',
-    url: '/styles',
-  })
-
-  const stylesList = responseStylesListGet.json()
-
+  const stylesList = server.listStyles()
   t.equal(stylesList.length, 1)
 
-  const responseStyleGet = await server.inject({
+  const responseStyleGet = await fastifyInstance.inject({
     method: 'GET',
-    url: stylesList[0].url,
+    url: `/styles/${stylesList[0].id}`,
   })
 
   t.equal(responseStyleGet.statusCode, 200)


### PR DESCRIPTION
This is the next step in [a larger refactor][0] where we replace the HTTP API with a JS one.

[0]: https://github.com/digidem/mapeo-map-server/issues/111

BREAKING CHANGE: `GET /styles` replaced with `listStyles()`