### PR TITLE
chore!: drop Node 16 support

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16.17.1, 18.17.1, 20.x]
+        node-version: [18.17.1, 20.x]
 
     steps:
       - uses: actions/checkout@v3

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,7 @@
         "typescript": "^5.3.3"
       },
       "engines": {
-        "node": ">=16.17.1"
+        "node": ">=18.17.1"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/app.js",
   "types": "dist/app.d.ts",
   "engines": {
-    "node": ">=16.17.1"
+    "node": ">=18.17.1"
   },
   "scripts": {
     "dev": "ts-node-dev --files --transpile-only --respawn --no-notify ./server.ts | pino-pretty",


### PR DESCRIPTION
This removes Node 16 support, given that (1) it is deprecated (2) it [is no longer used in CoMapeo][0].

[0]: https://github.com/digidem/CoMapeo-mobile/pull/194