### PR TITLE
refactor!: move MBTiles import from HTTP API to JS API

### DIFF
--- a/API.md
+++ b/API.md
@@ -123,19 +123,6 @@ Create a tileset. Returns the created tileset TileJSON if successful.
 
 Update a tileset. Returns the updated tileset TileJSON if successful.
 
-### `POST /tilesets/import`
-
-- Body
-  - `filePath: string`: An absolute path to the location of the file to import.
-
-Create a tileset by importing an existing file. If successful, a response with the following payload will be returned:
-
-- `import: { id: string }`: Information about the import that is created. The `id` can be used to get the information about the import or its progress (see [Imports](#imports)).
-- `style: { id: string } | null`: Information about the style that is created. As of now, a style is automatically generated for a MBTiles import. There may be cases where this behavior changes based on import type, so this field can potentially be `null`.
-- `tileset: TileJSON`: The tileset that is created, adhering to the [TileJSON spec](https://github.com/mapbox/tilejson-spec).
-
-As of now, only [MBTiles](https://github.com/mapbox/mbtiles-spec) files are supported, although there are plans to support other kinds of imports in the future.
-
 ---
 
 ## Tiles

--- a/src/api/errors.ts
+++ b/src/api/errors.ts
@@ -41,23 +41,30 @@ export const UnsupportedMBTilesFormatError = createError(
   400
 )
 
-export const MBTilesImportTargetMissingError = createError(
-  'FST_MBTILES_IMPORT_TARGET_MISSING',
-  'mbtiles file at `%s` could not be read',
-  400
-)
+export class MBTilesImportTargetMissingError extends Error {
+  readonly code = 'MBTILES_IMPORT_TARGET_MISSING'
+  constructor(filePath: string) {
+    super(`mbtiles file at ${JSON.stringify(filePath)} could not be read`)
+  }
+}
 
-export const MBTilesInvalidMetadataError = createError(
-  'FST_MBTILES_INVALID_METADATA',
-  'mbtiles file has invalid metadata schema',
-  400
-)
+export class MBTilesInvalidMetadataError extends Error {
+  readonly code = 'MBTILES_INVALID_METADATA'
+  constructor() {
+    super('mbtiles file has invalid metadata schema')
+  }
+}
 
-export const MBTilesCannotReadError = createError(
-  'FST_MBTILES_CANNOT_READ',
-  'mbtiles file could not be read properly: %s',
-  400
-)
+export class MBTilesCannotReadError extends Error {
+  readonly code = 'MBTILES_CANNOT_READ'
+  constructor(additionalMessage: unknown) {
+    super(
+      `mbtiles file could not be read properly: ${JSON.stringify(
+        additionalMessage
+      )}`
+    )
+  }
+}
 
 export const UpstreamJsonValidationError = createError(
   'FST_UPSTREAM_VALIDATION',

--- a/src/api/imports.ts
+++ b/src/api/imports.ts
@@ -74,7 +74,7 @@ function createImportsApi({
         if (data.type !== 'progress') break
       }
     },
-    importMBTiles(filePath: string, baseApiUrl: string) {
+    async importMBTiles(filePath: string, baseApiUrl: string) {
       const filePathWithExtension =
         path.extname(filePath) === '.mbtiles' ? filePath : filePath + '.mbtiles'
 

--- a/src/map-server.ts
+++ b/src/map-server.ts
@@ -76,6 +76,23 @@ export default class MapServer {
   }
 
   /**
+   * Create a tileset by importing an existing file.
+   *
+   * @param filePath An absolute path to the location of the file to import.
+   * @param baseApiUrl The base API URL for the imported mbtiles.
+   */
+  importMBTiles(
+    filePath: string,
+    baseApiUrl: string
+  ): Promise<{
+    import: IdResource
+    style: null | IdResource
+    tileset: TileJSON & IdResource
+  }> {
+    return this.#api.importMBTiles(filePath, baseApiUrl)
+  }
+
+  /**
    * Get all tilesets.
    */
   listTilesets(baseApiUrl: string): Array<TileJSON & IdResource> {

--- a/src/routes/tilesets.ts
+++ b/src/routes/tilesets.ts
@@ -39,16 +39,6 @@ const PutTilesetParamsSchema = T.Object({
   tilesetId: T.String(),
 })
 
-const ImportMBTilesRequestBodySchema = T.Object({
-  filePath: T.String(),
-})
-
-const ImportMBTilesResponseBodySchema = T.Object({
-  import: T.Object({ id: T.String() }),
-  style: T.Union([T.Object({ id: T.String() }), T.Null()]),
-  tileset: TileJSONSchema,
-})
-
 const tilesets: FastifyPluginAsync = async function (fastify) {
   fastify.get<{
     Params: Static<typeof GetTilesetParamsSchema>
@@ -166,26 +156,6 @@ const tilesets: FastifyPluginAsync = async function (fastify) {
       )
       reply.header('Location', `${fastify.prefix}/${tilejson.id}`)
       return tilejson
-    }
-  )
-
-  fastify.post<{ Body: Static<typeof ImportMBTilesRequestBodySchema> }>(
-    '/import',
-    {
-      schema: {
-        body: ImportMBTilesRequestBodySchema,
-        response: {
-          200: ImportMBTilesResponseBodySchema,
-        },
-      },
-    },
-    async function (request, reply) {
-      const result = await this.api.importMBTiles(
-        request.body.filePath,
-        getBaseApiUrl(request)
-      )
-      reply.header('Location', `${fastify.prefix}/${result.tileset.id}`)
-      return result
     }
   )
 }

--- a/test/e2e/styles.test.js
+++ b/test/e2e/styles.test.js
@@ -353,27 +353,22 @@ test('DELETE /styles/:styleId when style exists returns 204 status code and empt
 test('DELETE /styles/:styleId works for style created from tileset import', async (t) => {
   t.plan(5)
 
-  const server = createFastifyServer(t)
-
-  const importResponse = await server.inject({
-    method: 'POST',
-    url: '/tilesets/import',
-    payload: { filePath: sampleMbTilesPath },
-  })
+  const server = createServer(t)
+  const { fastifyInstance } = server
 
   const {
     tileset: { id: createdTilesetId },
     style: { id: createdStyleId },
-  } = importResponse.json()
+  } = await server.importMBTiles(sampleMbTilesPath, 'https://example.com')
 
-  const getStyleResponseBefore = await server.inject({
+  const getStyleResponseBefore = await fastifyInstance.inject({
     method: 'GET',
     url: `/styles/${createdStyleId}`,
   })
 
   t.equal(getStyleResponseBefore.statusCode, 200, 'style created')
 
-  const responseDelete = await server.inject({
+  const responseDelete = await fastifyInstance.inject({
     method: 'DELETE',
     url: `/styles/${createdStyleId}`,
   })
@@ -382,14 +377,14 @@ test('DELETE /styles/:styleId works for style created from tileset import', asyn
 
   t.equal(responseDelete.body, '')
 
-  const getStyleResponseAfter = await server.inject({
+  const getStyleResponseAfter = await fastifyInstance.inject({
     method: 'GET',
     url: `/styles/${createdStyleId}`,
   })
 
   t.equal(getStyleResponseAfter.statusCode, 404, 'style is properly deleted')
 
-  const tilesetResponseGet = await server.inject({
+  const tilesetResponseGet = await fastifyInstance.inject({
     method: 'GET',
     url: `/tilesets/${createdTilesetId}`,
   })

--- a/test/test-helpers/assertions.js
+++ b/test/test-helpers/assertions.js
@@ -1,0 +1,26 @@
+// @ts-check
+const assert = require('node:assert/strict')
+
+/**
+ * Wraps [Node's assert.rejects][0].
+ *
+ * This exists because:
+ *
+ * 1. Tape doesn't support it
+ * 2. We eventually want to use Node's built-in test runner
+ *
+ * [0]: https://nodejs.org/api/assert.html#assertrejectsasyncfn-error-message
+ *
+ * @param {import('tape').Test} t
+ * @param {Parameters<typeof assert.rejects>} args
+ * @returns {Promise<void>}
+ */
+async function assertRejects(t, ...args) {
+  await assert.rejects(...args)
+
+  const lastArg = args[args.length - 1]
+  const passMessage =
+    typeof lastArg === 'string' ? lastArg : 'expected rejection'
+  t.pass(passMessage)
+}
+exports.assertRejects = assertRejects


### PR DESCRIPTION
Yet another step in [a larger refactor][0] where we replace the HTTP API with a JS one.

[0]: https://github.com/digidem/mapeo-map-server/issues/111