### PR TITLE
chore: avoid materializing array in some cases

### DIFF
--- a/src/map-server.ts
+++ b/src/map-server.ts
@@ -4,6 +4,7 @@ import createFastify, { FastifyInstance, FastifyServerOptions } from 'fastify'
 import Database, { type Database as DatabaseInstance } from 'better-sqlite3'
 import Piscina from 'piscina'
 import FastifyStatic from '@fastify/static'
+import { map } from 'iterpal'
 
 import './type-extensions' // necessary to make sure that the fastify types are augmented
 import createApi, { type Api } from './api'
@@ -92,7 +93,8 @@ export default class MapServer {
       // without closing the DB connections in thread. This is kind-of hacky:
       // It relies on the MessagePort being closed when the worker thread is done.
       await Promise.all(
-        [...this.#activeImports.values()].map(
+        map(
+          this.#activeImports.values(),
           (port) =>
             new Promise((res) => {
               port.once('close', res)

--- a/src/routes/styles.ts
+++ b/src/routes/styles.ts
@@ -3,6 +3,7 @@ import createError from '@fastify/error'
 import got from 'got'
 import { Static, Type as T } from '@sinclair/typebox'
 import path from 'path'
+import { every } from 'iterpal'
 
 import { normalizeStyleURL } from '../lib/mapbox_urls'
 import { StyleJSON, createIdFromStyleUrl, validate } from '../lib/stylejson'
@@ -108,7 +109,8 @@ const styles: FastifyPluginAsync = async function (fastify) {
       })
 
       if (
-        [...upstreamSprites.values()].every(
+        every(
+          upstreamSprites.values(),
           (spriteInfo) => spriteInfo instanceof Error
         )
       ) {


### PR DESCRIPTION
This change should have no impact on functionality.

We had some code that materialized an iterable into an array so we could call `.map` or `.every` on it. We can use Iterpal to do this instead, avoiding the extra array allocations.