### PR TITLE
refactor!: move tileset creation HTTP API to JS API

### DIFF
--- a/API.md
+++ b/API.md
@@ -107,13 +107,6 @@ This endpoint goes through the following steps to determine what to respond with
 
 Retrieve the tilejson definition of a tileset. Adheres to the [TileJSON spec](https://github.com/mapbox/tilejson-spec).
 
-### `POST /tilesets`
-
-- Body
-  - A valid TileJSON definition that adheres to the [TileJSON spec](https://github.com/mapbox/tilejson-spec).
-
-Create a tileset. Returns the created tileset TileJSON if successful.
-
 ### `PUT /tilesets/:tilesetId`
 
 - Params

--- a/API.md
+++ b/API.md
@@ -123,19 +123,6 @@ Create a tileset. Returns the created tileset TileJSON if successful.
 
 Update a tileset. Returns the updated tileset TileJSON if successful.
 
-### `POST /tilesets/import`
-
-- Body
-  - `filePath: string`: An absolute path to the location of the file to import.
-
-Create a tileset by importing an existing file. If successful, a response with the following payload will be returned:
-
-- `import: { id: string }`: Information about the import that is created. The `id` can be used to get the information about the import or its progress (see [Imports](#imports)).
-- `style: { id: string } | null`: Information about the style that is created. As of now, a style is automatically generated for a MBTiles import. There may be cases where this behavior changes based on import type, so this field can potentially be `null`.
-- `tileset: TileJSON`: The tileset that is created, adhering to the [TileJSON spec](https://github.com/mapbox/tilejson-spec).
-
-As of now, only [MBTiles](https://github.com/mapbox/mbtiles-spec) files are supported, although there are plans to support other kinds of imports in the future.
-
 ---
 
 ## Tiles

--- a/src/api/errors.ts
+++ b/src/api/errors.ts
@@ -41,23 +41,30 @@ export const UnsupportedMBTilesFormatError = createError(
   400
 )
 
-export const MBTilesImportTargetMissingError = createError(
-  'FST_MBTILES_IMPORT_TARGET_MISSING',
-  'mbtiles file at `%s` could not be read',
-  400
-)
+export class MBTilesImportTargetMissingError extends Error {
+  readonly code = 'MBTILES_IMPORT_TARGET_MISSING'
+  constructor(filePath: string) {
+    super(`mbtiles file at ${JSON.stringify(filePath)} could not be read`)
+  }
+}
 
-export const MBTilesInvalidMetadataError = createError(
-  'FST_MBTILES_INVALID_METADATA',
-  'mbtiles file has invalid metadata schema',
-  400
-)
+export class MBTilesInvalidMetadataError extends Error {
+  readonly code = 'MBTILES_INVALID_METADATA'
+  constructor() {
+    super('mbtiles file has invalid metadata schema')
+  }
+}
 
-export const MBTilesCannotReadError = createError(
-  'FST_MBTILES_CANNOT_READ',
-  'mbtiles file could not be read properly: %s',
-  400
-)
+export class MBTilesCannotReadError extends Error {
+  readonly code = 'MBTILES_CANNOT_READ'
+  constructor(additionalMessage: unknown) {
+    super(
+      `mbtiles file could not be read properly: ${JSON.stringify(
+        additionalMessage
+      )}`
+    )
+  }
+}
 
 export const UpstreamJsonValidationError = createError(
   'FST_UPSTREAM_VALIDATION',

--- a/src/api/imports.ts
+++ b/src/api/imports.ts
@@ -74,7 +74,7 @@ function createImportsApi({
         if (data.type !== 'progress') break
       }
     },
-    importMBTiles(filePath: string, baseApiUrl: string) {
+    async importMBTiles(filePath: string, baseApiUrl: string) {
       const filePathWithExtension =
         path.extname(filePath) === '.mbtiles' ? filePath : filePath + '.mbtiles'
 

--- a/src/api/tilesets.ts
+++ b/src/api/tilesets.ts
@@ -14,7 +14,7 @@ import {
 
 export interface TilesetsApi {
   createTileset(
-    tileset: TileJSON,
+    tileset: Readonly<TileJSON>,
     baseApiUrl: string,
     // `upstreamUrl` should be an http-based url
     // e.g. for a mapbox url, it should be "https://api.mapbox.com/..."

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -32,9 +32,12 @@ export function encodeBase32(buf: Buffer): string {
  * an id field, so we use the tile URL as an identifier (assumes two tilejsons
  * refering to the same tile URL are the same)
  */
-export function getTilesetId(tilejson: TileJSON): string {
+export function getTilesetId(tilejson: Readonly<TileJSON>): string {
   // If the tilejson has no id, use the tile URL as the id
-  const id = tilejson.id || tilejson.tiles.sort()[0]
+  const id = tilejson.id || tilejson.tiles.concat().sort()[0]
+  if (!id) {
+    throw new Error('Could not derive tileset ID')
+  }
   return encodeBase32(hash(id))
 }
 

--- a/src/map-server.ts
+++ b/src/map-server.ts
@@ -76,6 +76,23 @@ export default class MapServer {
   }
 
   /**
+   * Create a tileset by importing an existing file.
+   *
+   * @param filePath An absolute path to the location of the file to import.
+   * @param baseApiUrl The base API URL for the imported mbtiles.
+   */
+  importMBTiles(
+    filePath: string,
+    baseApiUrl: string
+  ): Promise<{
+    import: IdResource
+    style: null | IdResource
+    tileset: TileJSON & IdResource
+  }> {
+    return this.#api.importMBTiles(filePath, baseApiUrl)
+  }
+
+  /**
    * Get all tilesets.
    */
   listTilesets(baseApiUrl: string): Array<TileJSON & IdResource> {

--- a/src/map-server.ts
+++ b/src/map-server.ts
@@ -99,6 +99,19 @@ export default class MapServer {
     return this.#api.listTilesets(baseApiUrl)
   }
 
+  /**
+   * Create a tileset. Returns the created tileset TileJSON if successful.
+   */
+  createTileset(
+    tileset: Readonly<TileJSON>,
+    baseApiUrl: string
+  ): TileJSON & IdResource {
+    // TODO: Add an optional `upstreamUrl` field so that we can fetch from upstream?
+    const result = this.#api.createTileset(tileset, baseApiUrl)
+    this.#api.createStyleForTileset(result, result.name)
+    return result
+  }
+
   listen(port: number | string, host?: string): Promise<string> {
     return this.fastifyInstance.listen(port, host)
   }

--- a/src/routes/tilesets.ts
+++ b/src/routes/tilesets.ts
@@ -62,30 +62,6 @@ const tilesets: FastifyPluginAsync = async function (fastify) {
     }
   )
 
-  // TODO: Update body to include an optional `upstreamUrl` field so that we can fetch from upstream?
-  fastify.post<{ Body: TileJSON }>(
-    '/',
-    {
-      schema: {
-        body: TileJSONSchema,
-        response: {
-          200: TileJSONSchema,
-        },
-      },
-    },
-    async function (request, reply) {
-      const tileset = this.api.createTileset(
-        request.body,
-        getBaseApiUrl(request)
-      )
-
-      this.api.createStyleForTileset(tileset, tileset.name)
-
-      reply.header('Location', `${fastify.prefix}/${tileset.id}`)
-      return tileset
-    }
-  )
-
   fastify.get<{
     Params: Static<typeof GetTileParamsSchema>
     Querystring: Static<typeof GetTileQuerystringSchema>

--- a/src/routes/tilesets.ts
+++ b/src/routes/tilesets.ts
@@ -39,16 +39,6 @@ const PutTilesetParamsSchema = T.Object({
   tilesetId: T.String(),
 })
 
-const ImportMBTilesRequestBodySchema = T.Object({
-  filePath: T.String(),
-})
-
-const ImportMBTilesResponseBodySchema = T.Object({
-  import: T.Object({ id: T.String() }),
-  style: T.Union([T.Object({ id: T.String() }), T.Null()]),
-  tileset: TileJSONSchema,
-})
-
 const tilesets: FastifyPluginAsync = async function (fastify) {
   fastify.get<{
     Params: Static<typeof GetTilesetParamsSchema>
@@ -166,26 +156,6 @@ const tilesets: FastifyPluginAsync = async function (fastify) {
       )
       reply.header('Location', `${fastify.prefix}/${tilejson.id}`)
       return tilejson
-    }
-  )
-
-  fastify.post<{ Body: Static<typeof ImportMBTilesRequestBodySchema> }>(
-    '/import',
-    {
-      schema: {
-        body: ImportMBTilesRequestBodySchema,
-        response: {
-          200: ImportMBTilesResponseBodySchema,
-        },
-      },
-    },
-    async function (request, reply) {
-      const result = await this.api.importMBTiles(
-        request.body.filePath,
-        getBaseApiUrl(request)
-      )
-      reply.header('Location', `${fastify.prefix}/${result.tileset.id}`)
-      return result
     }
   )
 }

--- a/test/e2e/styles.test.js
+++ b/test/e2e/styles.test.js
@@ -353,27 +353,22 @@ test('DELETE /styles/:styleId when style exists returns 204 status code and empt
 test('DELETE /styles/:styleId works for style created from tileset import', async (t) => {
   t.plan(5)
 
-  const server = createFastifyServer(t)
-
-  const importResponse = await server.inject({
-    method: 'POST',
-    url: '/tilesets/import',
-    payload: { filePath: sampleMbTilesPath },
-  })
+  const server = createServer(t)
+  const { fastifyInstance } = server
 
   const {
     tileset: { id: createdTilesetId },
     style: { id: createdStyleId },
-  } = importResponse.json()
+  } = await server.importMBTiles(sampleMbTilesPath, 'https://example.com')
 
-  const getStyleResponseBefore = await server.inject({
+  const getStyleResponseBefore = await fastifyInstance.inject({
     method: 'GET',
     url: `/styles/${createdStyleId}`,
   })
 
   t.equal(getStyleResponseBefore.statusCode, 200, 'style created')
 
-  const responseDelete = await server.inject({
+  const responseDelete = await fastifyInstance.inject({
     method: 'DELETE',
     url: `/styles/${createdStyleId}`,
   })
@@ -382,14 +377,14 @@ test('DELETE /styles/:styleId works for style created from tileset import', asyn
 
   t.equal(responseDelete.body, '')
 
-  const getStyleResponseAfter = await server.inject({
+  const getStyleResponseAfter = await fastifyInstance.inject({
     method: 'GET',
     url: `/styles/${createdStyleId}`,
   })
 
   t.equal(getStyleResponseAfter.statusCode, 404, 'style is properly deleted')
 
-  const tilesetResponseGet = await server.inject({
+  const tilesetResponseGet = await fastifyInstance.inject({
     method: 'GET',
     url: `/tilesets/${createdTilesetId}`,
   })

--- a/test/test-helpers/assertions.js
+++ b/test/test-helpers/assertions.js
@@ -1,0 +1,26 @@
+// @ts-check
+const assert = require('node:assert/strict')
+
+/**
+ * Wraps [Node's assert.rejects][0].
+ *
+ * This exists because:
+ *
+ * 1. Tape doesn't support it
+ * 2. We eventually want to use Node's built-in test runner
+ *
+ * [0]: https://nodejs.org/api/assert.html#assertrejectsasyncfn-error-message
+ *
+ * @param {import('tape').Test} t
+ * @param {Parameters<typeof assert.rejects>} args
+ * @returns {Promise<void>}
+ */
+async function assertRejects(t, ...args) {
+  await assert.rejects(...args)
+
+  const lastArg = args[args.length - 1]
+  const passMessage =
+    typeof lastArg === 'string' ? lastArg : 'expected rejection'
+  t.pass(passMessage)
+}
+exports.assertRejects = assertRejects


### PR DESCRIPTION
This is the next step in [a larger refactor][0] where we replace the HTTP API with a JS one.

Depends on #129.

[0]: https://github.com/digidem/mapeo-map-server/issues/111